### PR TITLE
Fix the asset name the installers download (all platforms 404)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Grab the archive for your platform from the
 extract, and run the bundled installer:
 
 ```bash
-tar -xzf reolink-cli-*-macos-arm64.tar.gz && cd reolink-cli-* && ./install.sh
+tar -xzf reolink-cli-*-external-darwin-arm64.tar.gz && cd reolink-cli-* && ./install.sh
 # Windows: extract the .zip and run .\install.ps1
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,18 +115,26 @@ Claude Code users: also run `/plugin uninstall reolink-cli` to clean the marketp
 ## Quick start
 
 ```bash
-# Bootstrap local config (gateway addr) + registry files
+# Write the config and registry templates. Both land in your OS config
+# directory and are created owner-only (0600).
 reolink-cli config init
 
-# Register your first camera — password is prompted, never on argv
-reolink-cli device add front-door --host 192.168.1.41 --user admin --tags outdoor,entry
-
-# Start the local gateway (needed by most control commands), then operate
+# Start the local gateway — most control commands route through it
 reolink-cli gateway start --addr 127.0.0.1:9000 &
-reolink-cli --camera front-door login
-reolink-cli --camera front-door info
-reolink-cli --camera front-door snapshot --file ./front-door.jpg
+export REOLINK_GATEWAY_ADDR=127.0.0.1:9000
+
+# Register your first camera. Pick a name of your own: `config init` writes
+# placeholder entries (front-door, garage, lab-v30) to show the file format,
+# and `device add` refuses to overwrite an existing one.
+reolink-cli device add porch --host 192.168.1.41 --user admin --tags outdoor,entry --password-stdin
+
+reolink-cli --camera porch login
+reolink-cli --camera porch info
+reolink-cli --camera porch snapshot --file ./porch.jpg
 ```
+
+The placeholder entries are examples, not cameras. Remove them once you have
+registered your own: `reolink-cli device remove front-door`.
 
 Bulk-import discovered devices (credentials via `REOLINK_PASSWORD`, never
 plaintext `--password` on the command line):

--- a/README.md
+++ b/README.md
@@ -212,7 +212,12 @@ Prebuilt binaries are published on each [Release](https://github.com/reolink/reo
 
 - macOS arm64 (Apple Silicon)
 - Linux x86_64
+- Linux arm64
 - Windows x86_64
+
+`self-update` covers macOS and Linux. On Windows it exits with the download
+link instead: the archive is a `.zip`, and a running `.exe` cannot be replaced
+in place — upgrade by extracting the new archive and running `install.ps1`.
 
 `preview play` expects `ffplay` on `PATH` (or pass `--player`, or set
 `REOLINK_PLAYER`).

--- a/install.ps1
+++ b/install.ps1
@@ -19,7 +19,10 @@ $rel = Invoke-RestMethod -Headers $headers -Uri "https://api.github.com/repos/$R
 $tag = $rel.tag_name
 if (-not $tag) { throw "could not resolve the latest release (public repo? set GITHUB_TOKEN if private)" }
 $ver   = $tag.TrimStart('v')
-$asset = "reolink-cli-$ver-windows-x86_64.zip"
+# Release archives carry the build flavour in the name so internal (Song P2P)
+# and customer (LAN-only) builds can never be mistaken for one another. Only
+# the external flavour is published here.
+$asset = "reolink-cli-$ver-external-windows-x86_64.zip"
 
 $tmp = Join-Path $env:TEMP ("reolink-install-" + [System.Guid]::NewGuid().ToString('N'))
 New-Item -ItemType Directory -Force -Path $tmp | Out-Null

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ command -v tar  >/dev/null 2>&1 || die "tar is required"
 
 os=$(uname -s); arch=$(uname -m)
 case "$os" in
-  Darwin) os=macos ;;
+  Darwin) os=darwin ;;
   Linux)  os=linux ;;
   *) die "unsupported OS '$os' — see https://github.com/$REPO/releases" ;;
 esac
@@ -35,7 +35,7 @@ case "$arch" in
 esac
 
 # macOS ships Apple Silicon only; Intel Macs are not supported.
-if [ "$os" = macos ] && [ "$arch" = x86_64 ]; then
+if [ "$os" = darwin ] && [ "$arch" = x86_64 ]; then
   die "macOS Intel (x86_64) is not supported — Apple Silicon (arm64) only. See https://github.com/$REPO/releases"
 fi
 
@@ -49,7 +49,10 @@ tag=$(curl -fsSL -A reolink-cli-install ${AUTH:+-H "$AUTH"} \
   | sed -n 's/.*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)
 [ -n "$tag" ] || die "could not resolve the latest release (is the repo public? set GITHUB_TOKEN if it is private)"
 ver="${tag#v}"
-asset="reolink-cli-${ver}-${os}-${arch}.tar.gz"
+# Release archives carry the build flavour in the name so internal (Song P2P)
+# and customer (LAN-only) builds can never be mistaken for one another. Only
+# the external flavour is published here.
+asset="reolink-cli-${ver}-external-${os}-${arch}.tar.gz"
 
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT INT TERM

--- a/skills/reolink-cli/SKILL.md
+++ b/skills/reolink-cli/SKILL.md
@@ -148,7 +148,7 @@ Pass `alias`, `host`, or `uid` per tool call to target a specific camera; the se
 
 **Other safety rules** (kept verbatim — these break things if violated):
 
-- **Target selectors are global options** (pre-subcommand). **Forbidden** positional. Priority: `--camera` > `--host` > `--uid` > env. Batch: `--tag`, `--cameraes A,B`, `--all-devices`. **Must** pass `--channel N` for NVR.
+- **Target selectors are global options** (pre-subcommand). **Forbidden** positional. Priority: `--camera` > `--host` > `--uid` > env. Batch: `--tag`, `--cameras A,B`, `--all-devices`. **Must** pass `--channel N` for NVR.
 - **Credential safety**: **Forbidden** `--password PLAIN` on argv. **Must** use `--camera <name>` (from `aliases.toml` 0600), `REOLINK_PASSWORD` env, or `--password-stdin`. If no camera registered and op isn't trivially read-only, ask user to run `device add` first.
 - **Stored passwords are encrypted** (`RLENC1:…`, AES-256-GCM) with the key in `credentials.key` next to `aliases.toml`; a plaintext config is converted automatically on first use. Do **not** try to read a password out of `aliases.toml` — it is ciphertext, and there is no command that reveals it. Backing up or moving a config means copying **both** files; with only one of them the passwords are unrecoverable and must be re-entered via `device update <camera> --password-stdin`. If a command reports a password that "cannot be decrypted", the key file is missing or mismatched — that is not a wrong-password problem, so do not retry with guesses.
 - **Pre-write read**: **Must** `get` current value before any write that's NOT covered by an `apply` recipe; confirm side effects from the table below; verify NVR channel.
@@ -158,7 +158,7 @@ Pass `alias`, `host`, or `uid` per tool call to target a specific camera; the se
 
 ## Global Options
 
-`--host`/`--uid`/`--camera`/`--cameraes A,B`/`--tag`/`--all-devices`, `--user`/`--password`/`--channel`, `--protocol auto`, `--output json|text`, `--gateway-addr HOST:PORT`, `--config-file`/`--cameraes-file`. Env equivalents: `REOLINK_HOST/UID/ALIAS/USER/PASSWORD/CHANNEL/PROTOCOL/GATEWAY_ADDR/CONFIG_FILE/ALIASES_FILE`. Run `reolink-cli --help` or `<subcmd> --help` for exact flag shapes.
+`--host`/`--uid`/`--camera`/`--cameras A,B`/`--tag`/`--all-devices`, `--user`/`--password`/`--channel`, `--protocol auto`, `--output json|text`, `--gateway-addr HOST:PORT`, `--config-file`/`--cameras-file`. Env equivalents: `REOLINK_HOST/UID/ALIAS/USER/PASSWORD/CHANNEL/PROTOCOL/GATEWAY_ADDR/CONFIG_FILE/ALIASES_FILE`. Run `reolink-cli --help` or `<subcmd> --help` for exact flag shapes.
 
 ## Batch Operations
 
@@ -166,7 +166,7 @@ Pass `alias`, `host`, or `uid` per tool call to target a specific camera; the se
 - **Forbidden** enumerating with `--tag` then switching to `--camera` inside the same workflow.
 - Batch output has per-target `ok`; a single failure doesn't fail the batch. **Must** check `summary.failed > 0` and iterate `results[]`.
 
-**Degenerate case:** when a batch selector (`--tag X`, `--cameraes A`, `--all-devices`) resolves to *exactly one* device, the CLI emits the **single-target envelope** (`{ok, command, protocol, data}`), not the batch report. **Must** test `"summary" in response` to detect which shape you got. **Forbidden** assuming `results[]` exists.
+**Degenerate case:** when a batch selector (`--tag X`, `--cameras A`, `--all-devices`) resolves to *exactly one* device, the CLI emits the **single-target envelope** (`{ok, command, protocol, data}`), not the batch report. **Must** test `"summary" in response` to detect which shape you got. **Forbidden** assuming `results[]` exists.
 
 ## Error Recovery
 


### PR DESCRIPTION
The one-line installers in the README 404 on **every platform**. Verified just now against the live public repo:

```
==> downloading reolink-cli-0.10.0-macos-arm64.tar.gz (v0.10.0)
curl: (56) The requested URL returned error: 404
```

| Installer asks for | Actually published |
|---|---|
| `…-macos-arm64.tar.gz` | `…-external-darwin-arm64.tar.gz` |
| `…-linux-x86_64.tar.gz` | `…-external-linux-x86_64.tar.gz` |
| `…-linux-arm64.tar.gz` | `…-external-linux-arm64.tar.gz` |
| `…-windows-x86_64.zip` | `…-external-windows-x86_64.zip` |

Two drifts had accumulated: the archives gained an `-external` flavour segment so an internal build linking Song P2P can never be mistaken for the customer build, and the platform token moved from `macos` to `darwin`. Neither reached `install.sh` or `install.ps1`.

Also fixes the archive filename in the README's manual-download example.

**This is the install path the README leads with, so it is broken for every new user right now.**