### PR TITLE
docs: sync the distribution to the 0.10.1 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "reolink-cli",
       "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "source": "./",
       "author": {
         "name": "Reolink"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "author": {
     "name": "reolink"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Plugin for operating Reolink cameras through the local CLI.",
   "author": {
     "name": "Reolink"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "reolink-cli",
   "displayName": "Reolink CLI",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "author": {
     "name": "Reolink"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to the public `reolink-cli` distribution are documented here
 This is the customer-facing release history; it tracks the LAN-only (external)
 builds published as GitHub Releases.
 
+## [0.10.1] — 2026-07-27
+
+### Fixed
+
+- **`self-update` could never download anything.** It asked for
+  `reolink-cli-<ver>-macos-arm64.tar.gz` while the published archive is
+  `reolink-cli-<ver>-external-darwin-arm64.tar.gz` — all three supported
+  platforms were wrong. The archives had gained an `-external` flavour segment
+  so an internal build can never be mistaken for the customer build, and the
+  macOS token had moved from `macos` to `darwin`; neither reached the updater.
+  It stayed invisible because the download only happens when an update exists —
+  running it on the current version returns `already up to date` and never gets
+  that far.
+
+  Windows remains unsupported by `self-update` and now says so with the download
+  link: that archive is a `.zip` while the updater only untars, and a running
+  `.exe` cannot be replaced in place. Upgrade there by extracting the new
+  archive and running `install.ps1`.
+
+- **The agent skill misspelled `--cameras` as `--cameraes`.** A copied command
+  failed with an unrecognized-argument error.
+
+### Build
+
+- The packaging script now refuses to produce an archive whose filename the
+  updater cannot reconstruct, so this class of drift cannot ship again.
+
 ## [0.10.0] — 2026-07-25
 
 Stored camera passwords are no longer kept in plaintext.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **A local-first command-line tool for operating Reolink cameras — JSON by default, with a built-in MCP server and a cross-agent skill so AI agents drive the same core.**
 
-![version](https://img.shields.io/badge/version-0.10.0-blue)
+![version](https://img.shields.io/badge/version-0.10.1-blue)
 ![platform](https://img.shields.io/badge/platform-macOS%20·%20Linux%20·%20Windows-lightgrey)
 ![build](https://img.shields.io/badge/build-external%20·%20LAN--only-green)
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "contextFileName": "GEMINI.md"
 }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "reolink-cli",
   "name": "Reolink CLI",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "author": {
     "name": "Reolink"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "type": "module",
   "description": "Operate Reolink cameras locally via reolink-cli.",
   "main": ".opencode/plugins/reolink-cli.js",

--- a/skills/reolink-cli/references/setup.md
+++ b/skills/reolink-cli/references/setup.md
@@ -27,7 +27,7 @@ tar -xzf "$tmp"/*.tar.gz -C "$tmp"
 cp "$tmp"/*/bin/reolink-cli "$tmp"/*/bin/reolink-gateway "$BIN/"
 chmod +x "$BIN/reolink-cli" "$BIN/reolink-gateway"; rm -rf "$tmp"
 case ":$PATH:" in *":$BIN:"*) ;; *) echo "NOTE: add $BIN to your PATH";; esac
-reolink-cli --version   # → 0.10.0 (external · LAN-only)
+reolink-cli --version   # → 0.10.1 (external · LAN-only)
 ```
 
 Windows: download the `...-windows-x86_64.zip` from the Releases page and put


### PR DESCRIPTION
## What changes

Syncs the distribution to the published v0.10.1 release (part of #3): adds the missing `[0.10.1] — 2026-07-27` CHANGELOG entry (adapted from the release notes) and bumps `0.10.0 → 0.10.1` in all nine version locations (`package.json`, the plugin manifests, the README badge, `setup.md`) so they agree with the published release, per the manifests-in-step rule in CONTRIBUTING.

The `[0.6.0] — unreleased` line itself is deliberately **not** touched: its first-ship date is not recoverable from this repository (no pre-0.10.1 tag, release, or event survives), so filling it in needs a maintainer who knows the date — that part stays open on #3.

## How it was verified

Docs/manifest-only change — no commands or camera behaviour affected. Verified with `grep -rn "0\.10\."` that every non-historical version reference now reads `0.10.1` and matches the latest published release (`gh release list` → `v0.10.1`, 2026-07-27). The CHANGELOG entry content is taken from the v0.10.1 GitHub release notes, not written from memory.

## Checklist

- [x] No password, camera UID, or private network address appears in the diff
- [x] Docs updated if a flag, output field, or default changed
- [ ] `cargo test --workspace` passes — N/A: this repo contains no Rust source; docs/manifests only
