### PR TITLE
docs: drop the stale 'while this repository is private' install notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,13 +282,6 @@ you own or are authorised to administer.
 
 ## Installers
 
-> **While this repository is private**, the one-line installers and the release
-> download URLs return 404 for anonymous callers — GitHub does not serve private
-> content that way. Until it is made public, export a `GITHUB_TOKEN` with access
-> to this repository before running an installer, or fetch the archive with
-> `gh release download`.
-
-
 `install.sh` and `install.ps1` fetch and run executables, so here is exactly
 what they do:
 

--- a/install.sh
+++ b/install.sh
@@ -8,8 +8,6 @@
 # `npx skills add reolink/reolink-cli` instead (it fetches the binary for you).
 #
 # Env overrides: REOLINK_REPO=owner/repo, REOLINK_PREFIX=/install/root.
-# (While the repo is private, GitHub won't serve release assets over the public
-#  download URL — test with `gh release download` until it is public.)
 set -eu
 
 REPO="${REOLINK_REPO:-reolink/reolink-cli}"


### PR DESCRIPTION
## What changes

Fixes #4. The repository is public now, but the README's Installers section and the `install.sh` header comment still said the installers return 404 for anonymous callers and that a `GITHUB_TOKEN` is needed "until it is made public". Both stale notes are removed.

The conditional fallback error strings ("set `GITHUB_TOKEN` if it is private") in `install.sh` / `install.ps1` are kept, as discussed in the issue — they only fire when the release API can't be resolved and are still correct there.

## How it was verified

Repo visibility confirmed public via `gh repo view` (`visibility: PUBLIC`). The `install.sh` change removes two comment lines only — no executable logic changed and the SHA256SUMS verification is untouched; `sh -n install.sh` passes. README change is a deleted blockquote, no commands affected.

## Checklist

- [x] No password, camera UID, or private network address appears in the diff
- [x] Docs updated if a flag, output field, or default changed
- [ ] `cargo test --workspace` passes — N/A: this repo contains no Rust source; docs/installer comment only
