### PR TITLE
Add a version-sync check; stop calling 0.6.0 "unreleased"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -249,9 +249,10 @@ Patch release. Fixes found in a pre-release audit, verified on real hardware.
   address works out of the box.
 - **Prebuilt binaries** — macOS arm64, Linux x86_64, Windows x86_64.
 
-## [0.6.0] — unreleased
+## [0.6.0] — not published
 
-Initial public distribution.
+Prepared as the first public distribution but never released here; the
+first published release was 0.7.0. Kept for the record of what it covered.
 
 - LAN-only camera operation: discover, login, info, snapshot, live preview, PTZ,
   IR / spotlight / LEDs, image tuning, OSD, motion + AI detection, recording +

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,18 @@ you want. We implement it upstream and it arrives in the next release.
   the docs that had never been executed — a flag that did not exist, a
   subcommand that had been renamed. If you touch an example, run it and paste
   the output in the PR.
-- **Keep manifests in step.** The version appears in several manifests; they
-  must agree. Do not hand-edit a version to something no release uses.
+- **Keep manifests in step.** The version appears in nine places — seven
+  manifests, the README badge, and `skills/reolink-cli/references/setup.md` —
+  plus a CHANGELOG heading. They must all agree with the published release. Do
+  not hand-edit a version to something no release uses. Check with:
+
+  ```bash
+  ./scripts/check-version-sync.sh
+  ```
+
+  Doing this by hand has failed twice: once the plugin manifests were left
+  behind, once the whole repository stayed a version back while the release was
+  already published, so readers saw a stale badge over a newer download.
 - **Never commit real data.** No camera passwords, tokens, UIDs, serial
   numbers, private IPs, or footage — in code, docs, examples or screenshots.
   Use placeholders such as `192.168.1.42` and `<camera-password>`.

--- a/scripts/check-version-sync.sh
+++ b/scripts/check-version-sync.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+# Check that every version string in this repository agrees with the latest
+# published GitHub release.
+#
+#   ./scripts/check-version-sync.sh            # compare against the latest release
+#   ./scripts/check-version-sync.sh 0.10.1     # compare against a version you name
+#
+# Exits non-zero and lists every file that disagrees.
+#
+# Why this exists: the version appears in nine places, and keeping them in step
+# by hand failed twice in a row — once leaving the plugin manifests behind, once
+# leaving this entire repository on the previous version while the release was
+# already published. Readers saw a 0.10.0 badge over a 0.10.1 download. Checking
+# is cheap; remembering is not.
+set -eu
+
+cd "$(dirname "$0")/.."
+
+want="${1:-}"
+if [ -z "$want" ]; then
+  want=$(curl -fsSL -A version-sync-check \
+    "https://api.github.com/repos/reolink/reolink-cli/releases/latest" \
+    | sed -n 's/.*"tag_name":[[:space:]]*"v\{0,1\}\([^"]*\)".*/\1/p' | head -n1)
+  [ -n "$want" ] || { echo "could not resolve the latest release; pass a version explicitly" >&2; exit 2; }
+  echo "latest published release: $want"
+fi
+
+fail=0
+report() {
+  found="$2"
+  if [ "$found" != "$want" ]; then
+    printf '  MISMATCH  %-46s %s (want %s)\n' "$1" "${found:-<not found>}" "$want"
+    fail=1
+  else
+    printf '  ok        %-46s %s\n' "$1" "$found"
+  fi
+}
+
+# The JSON manifests each carry a "version" field. marketplace.json nests it
+# inside a plugin entry, so take the first match in every file rather than
+# assuming a fixed depth.
+for f in package.json openclaw.plugin.json gemini-extension.json \
+         .claude-plugin/plugin.json .claude-plugin/marketplace.json \
+         .codex-plugin/plugin.json .cursor-plugin/plugin.json; do
+  [ -f "$f" ] || continue
+  report "$f" "$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([0-9][^"]*\)".*/\1/p' "$f" | head -n1)"
+done
+
+report "README.md (badge)" \
+  "$(sed -n 's/.*version-\([0-9][0-9.]*\)-blue.*/\1/p' README.md | head -n1)"
+
+report "skills/reolink-cli/references/setup.md" \
+  "$(sed -n 's/.*reolink-cli --version.*# *→ *\([0-9][0-9.]*\).*/\1/p' \
+     skills/reolink-cli/references/setup.md | head -n1)"
+
+# The changelog is the one place the version must appear as a heading. A release
+# published without its entry is how a user ends up reading last version's notes.
+# Anchor the closing bracket: a prefix match would accept "## [0.10.1-rc]"
+# as the entry for 0.10.1.
+if grep -qE "^## \[?${want}\]? " CHANGELOG.md || grep -qE "^## \[?${want}\]?$" CHANGELOG.md; then
+  printf '  ok        %-46s has an entry\n' "CHANGELOG.md"
+else
+  printf '  MISMATCH  %-46s no "## [%s]" heading\n' "CHANGELOG.md" "$want"
+  fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo
+  echo "Version strings disagree with the published release."
+  exit 1
+fi
+echo
+echo "All version strings agree with $want."


### PR DESCRIPTION
Closes #3. Part of #7.

## Why

Keeping the version in step across nine files has failed **twice**:

- 0.10.0 — the plugin manifests were left on the previous version
- 0.10.1 — this entire repository stayed a version behind while the release was already published, so the README badge showed `0.10.0` over a `0.10.1` download. @ch-bas caught that one in #5, not us.

## What

`scripts/check-version-sync.sh` resolves the latest published release and compares all nine locations plus the CHANGELOG heading, listing every file that disagrees.

Verified in both directions — it passes on the current tree, and it catches both real mistakes when reproduced:

```
MISMATCH  package.json                    0.10.0 (want 0.10.1)
MISMATCH  CHANGELOG.md                    no "## [0.10.1]" heading
```

The changelog check first used a prefix match, which happily accepted `## [0.10.1-rc]` as the entry for `0.10.1`. The negative-control test is what exposed it; it now anchors the closing bracket.

## On the bump script in #7

Not added. Rewriting nine strings is one `sed` and happens once per release; the failure mode is *forgetting*, not mistyping. A checker catches forgetting — a second script you must remember to run does not. Leaving #7 open for the CI half if you want it wired to Actions.

## Also

`[0.6.0]` was marked "unreleased" while sitting below seven shipped versions, which reads as a pending release (#3). It was prepared but never published here — 0.7.0 was the first — so it now says that.