### PR TITLE
fix: purge on Windows used an env var uninstall.ps1 never reads

### DIFF
--- a/commands/uninstall.md
+++ b/commands/uninstall.md
@@ -31,14 +31,15 @@ The release tarball ships its own `uninstall.sh` / `uninstall.ps1`. Run them fro
 **Windows — purge:**
 
 ```powershell
-$env:REOLINK_PURGE = "1"; .\uninstall.ps1
+.\uninstall.ps1 --purge
 ```
 
 If the user no longer has the tarball on disk, falling back to manual removal works too:
 
 ```bash
-# macOS / Linux
-pkill -f reolink-gateway
+# macOS / Linux — kill only the gateway from this install prefix,
+# never gateways belonging to another installation
+pkill -f "$HOME/.local/bin/reolink-gateway"
 rm -f ~/.local/bin/reolink-cli ~/.local/bin/reolink-gateway
 # (purge only)
 rm -rf ~/.config/reolink-cli ~/.cache/reolink-cli ~/.local/state/reolink-cli


### PR DESCRIPTION
## What changes

Fixes #12. The `/reolink-cli:uninstall` slash command told Windows users to purge with `$env:REOLINK_PURGE = "1"` — an environment variable `uninstall.ps1` never reads (it only forwards arguments), so the user got a plain uninstall while being told their credentials were wiped. This exact misdocumentation was fixed in AGENTS.md for 0.9.1; the slash command file was missed. Now `.\uninstall.ps1 --purge` on both platforms.

Also scopes the manual fallback from `pkill -f reolink-gateway` (kills gateways from every install on the machine) to the full binary path of the prefix being removed, matching the prefix-scoping 0.9.1 established for `setup --uninstall`.

## How it was verified

Downloaded the real v0.10.1 release tarball (checksum-verified against its `SHA256SUMS`) and read its bundled `uninstall.ps1`: it only forwards `$args`, confirming the env var is never read. Cross-checked against AGENTS.md line 152 and the 0.9.1 CHANGELOG entry, which both state `--purge` is the only mechanism.

## Checklist

- [x] No password, camera UID, or private network address appears in the diff
- [x] Docs updated if a flag, output field, or default changed
- [ ] `cargo test --workspace` passes — N/A: this repo contains no Rust source; slash-command doc only
