### PR TITLE
fix: cache-clean slash command named a cache directory that does not exist

### DIFF
--- a/commands/cache-clean.md
+++ b/commands/cache-clean.md
@@ -1,9 +1,9 @@
 ---
-description: Preview + clean artifacts under ~/.cache/reolink older than 7 days
+description: Preview + clean artifacts under ~/.cache/reolink-cli older than 7 days
 argument-hint: [--older-than 30d]
 ---
 
-Clean old cache entries under `~/.cache/reolink/` (snapshots, TTS PCM clips, etc.).
+Clean old cache entries under `~/.cache/reolink-cli/` (snapshots, TTS PCM clips, etc.).
 
 **Step 1 — preview (dry-run, always first):**
 


### PR DESCRIPTION
## What changes

Fixes #13. The `/reolink-cli:cache-clean` slash command named `~/.cache/reolink/` in its frontmatter description and body; the CLI's cache root is `~/.cache/reolink-cli/`. The command itself was unaffected (the CLI resolves its own path), but anyone inspecting or deleting the named directory by hand was pointed at the wrong place.

## How it was verified

Ran `cache status` on the actual v0.10.1 binary (downloaded from the release, checksum-verified): it reports `root: ~/Library/Caches/reolink-cli` on macOS (`~/.cache/reolink-cli` on Linux). All other docs (SKILL.md, README.md, AGENTS.md) already use the `-cli` path.

## Checklist

- [x] No password, camera UID, or private network address appears in the diff
- [x] Docs updated if a flag, output field, or default changed
- [ ] `cargo test --workspace` passes — N/A: this repo contains no Rust source; slash-command doc only
