### PR TITLE
fix: AGENTS.md pointed agents at a version: frontmatter SKILL.md does not have

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,7 @@ reolink-cli cache status --output json 2>/dev/null \
 
 **Read `.data.commands`** from the `features` output before dispatching any subcommand. If a command in SKILL.md is missing from that list, the installed binary is older than the skill and the right response is to tell the user to upgrade by re-extracting their newest release tarball over the old one.
 
-If the binary version on disk and the version named in `SKILL.md` (`version:` frontmatter, see the local skill file) disagree, tell the user — the skill might be describing capabilities the binary doesn't have yet (or vice versa). Both should match the version printed by `reolink-cli --version`.
+If the binary and the installed skill disagree about capabilities, tell the user. The `features --output json` output above is the check: `.data.version` is the binary, `.data.claudeCodePluginVersion` is the skill tree the agent loaded (`null` when not installed as a Claude Code plugin), and `.data.cacheState` says whether they are in step — anything other than `in_sync` means the skill might describe capabilities the binary doesn't have yet (or vice versa), and the fix is `reolink-cli plugin refresh`.
 
 ---
 


### PR DESCRIPTION
## What changes

Fixes #14. AGENTS.md Part 5 told agents to compare the binary version against "the version named in `SKILL.md` (`version:` frontmatter)" — a field SKILL.md has never had (its frontmatter is `name`, `description`, `metadata`). The paragraph now points at the check the binary actually provides: `features --output json` → `.data.version` (binary), `.data.claudeCodePluginVersion` (loaded skill tree, `null` when not a Claude Code plugin), and `.data.cacheState`, with `plugin refresh` as the remedy — matching what SKILL.md already prescribes for `cache_state != in_sync`.

## How it was verified

Ran `features --output json` on the actual v0.10.1 binary (downloaded from the release, checksum-verified): all three fields are present (`version: "0.10.1"`, `claudeCodePluginVersion: null`, `cacheState: "no_plugin_cache"` on a machine without the plugin installed). Confirmed SKILL.md's frontmatter keys by reading the file.

## Checklist

- [x] No password, camera UID, or private network address appears in the diff
- [x] Docs updated if a flag, output field, or default changed
- [ ] `cargo test --workspace` passes — N/A: this repo contains no Rust source; docs only
