### PR TITLE
fix: install.ps1 continued silently when the archive lacked the binaries

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -66,8 +66,11 @@ try {
   Get-Process -Name reolink-gateway,reolink-cli -ErrorAction SilentlyContinue |
     Where-Object { $_.Path -like (Join-Path $Bin '*') } |
     ForEach-Object { Write-Host "stopping $($_.Name) (pid $($_.Id))"; Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue }
-  Get-ChildItem -Path $tmp -Recurse -Filter 'reolink-cli.exe'     | Select-Object -First 1 | ForEach-Object { Copy-Item $_.FullName (Join-Path $Bin 'reolink-cli.exe') -Force }
-  Get-ChildItem -Path $tmp -Recurse -Filter 'reolink-gateway.exe' | Select-Object -First 1 | ForEach-Object { Copy-Item $_.FullName (Join-Path $Bin 'reolink-gateway.exe') -Force }
+  foreach ($b in 'reolink-cli.exe', 'reolink-gateway.exe') {
+    $src = Get-ChildItem -Path $tmp -Recurse -Filter $b | Select-Object -First 1
+    if (-not $src) { throw "$b not found in the archive" }
+    Copy-Item $src.FullName (Join-Path $Bin $b) -Force
+  }
 } finally {
   Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
 }


### PR DESCRIPTION
## What changes

Fixes #15. When the extracted archive lacks a binary, `install.sh` dies with `"<name> not found in the archive"`, but `install.ps1` piped `Get-ChildItem` into `ForEach-Object` — an empty lookup copied nothing and the script carried on, only failing later at `config init` with an error that never names the real problem. Each binary is now resolved explicitly and the script throws `"<name> not found in the archive"`, mirroring install.sh.

## How it was verified

`pwsh` is not available on the machine this was written on, so the change was verified by review against install.sh's equivalent check rather than executed — flagging that honestly per the installer-change rule. The loop is plain PowerShell (`foreach` / `Get-ChildItem` / `throw` / `Copy-Item`), and `$ErrorActionPreference = 'Stop'` at the top of the script is unchanged. No change to SHA256 verification, process stopping, download logic, or what gets written where; no `sudo`/elevation added; nothing new is deleted or overwritten.

## Checklist

- [x] No password, camera UID, or private network address appears in the diff
- [x] Docs updated if a flag, output field, or default changed — no flag/output change
- [ ] `cargo test --workspace` passes — N/A: this repo contains no Rust source; installer script only
