### PR TITLE
docs: sync the distribution to the 0.10.2 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "reolink-cli",
       "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "source": "./",
       "author": {
         "name": "Reolink"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "author": {
     "name": "reolink"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Plugin for operating Reolink cameras through the local CLI.",
   "author": {
     "name": "Reolink"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "reolink-cli",
   "displayName": "Reolink CLI",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "author": {
     "name": "Reolink"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to the public `reolink-cli` distribution are documented here
 This is the customer-facing release history; it tracks the LAN-only (external)
 builds published as GitHub Releases.
 
+## [0.10.2] — 2026-07-29
+
+Both changes came from issues opened here.
+
+### Added
+
+- **`config get performance`** — live device load: `cpuUsedPercent`, `codeRate`,
+  `netDataRate` (#9). Verified on hardware: an E1 Outdoor reports 60% CPU.
+
+  Not every model implements it. Those answer with a device-level rejection
+  rather than a fabricated zero — a camera reported as 0% busy when it never
+  said so would be worse than an error. `codeRate` reads 0 on an idle camera and
+  only becomes meaningful while a stream is running; it is reported rather than
+  hidden, so you can tell "idle" from "not reported".
+
+  This is distinct from `benchmark`, which times the **client** round trip.
+
+### Fixed
+
+- **Protocol-detection failures blamed the host when the host was fine** (#10).
+  An NVR channel failed with `unable to detect protocol — device unreachable, or
+  not a Reolink v20/v30 device` while another channel on the same host worked in
+  the same session, sending the reporter to check VLAN routing and firewall
+  rules.
+
+  Each channel opens its own session, so the probe runs **per channel** —
+  blaming the host is wrong by construction whenever another channel is working.
+  The probe also collapsed four outcomes into one: connect timed out, connect
+  refused, **connected but no answer**, and unrecognised magic. That third case
+  matters: a device that is up but declining an additional connection looks
+  identical on the wire to one that is unreachable.
+
+  The message now names the channel and the actual failure, and points at
+  `--protocol v20` to skip the probe.
+
 ## [0.10.1] — 2026-07-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **A local-first command-line tool for operating Reolink cameras — JSON by default, with a built-in MCP server and a cross-agent skill so AI agents drive the same core.**
 
-![version](https://img.shields.io/badge/version-0.10.1-blue)
+![version](https://img.shields.io/badge/version-0.10.2-blue)
 ![platform](https://img.shields.io/badge/platform-macOS%20·%20Linux%20·%20Windows-lightgrey)
 ![build](https://img.shields.io/badge/build-external%20·%20LAN--only-green)
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "contextFileName": "GEMINI.md"
 }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "reolink-cli",
   "name": "Reolink CLI",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "author": {
     "name": "Reolink"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "type": "module",
   "description": "Operate Reolink cameras locally via reolink-cli.",
   "main": ".opencode/plugins/reolink-cli.js",

--- a/skills/reolink-cli/references/setup.md
+++ b/skills/reolink-cli/references/setup.md
@@ -27,7 +27,7 @@ tar -xzf "$tmp"/*.tar.gz -C "$tmp"
 cp "$tmp"/*/bin/reolink-cli "$tmp"/*/bin/reolink-gateway "$BIN/"
 chmod +x "$BIN/reolink-cli" "$BIN/reolink-gateway"; rm -rf "$tmp"
 case ":$PATH:" in *":$BIN:"*) ;; *) echo "NOTE: add $BIN to your PATH";; esac
-reolink-cli --version   # → 0.10.1 (external · LAN-only)
+reolink-cli --version   # → 0.10.2 (external · LAN-only)
 ```
 
 Windows: download the `...-windows-x86_64.zip` from the Releases page and put


### PR DESCRIPTION
Adds the `[0.10.2]` CHANGELOG entry and moves all nine version locations.

Verified with the checker added in #11 — the one added because this same sync was missed by hand twice:

```
$ ./scripts/check-version-sync.sh
latest published release: 0.10.2
  ok        package.json                                   0.10.2
  ...
  ok        CHANGELOG.md                                   has an entry

All version strings agree with 0.10.2.
```

The release itself (#9 `config get performance`, #10 probe error message) is already published.