### PR TITLE
Fix three docs that describe things the tool does not have

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,7 @@ reolink-cli cache status --output json 2>/dev/null \
 
 **Read `.data.commands`** from the `features` output before dispatching any subcommand. If a command in SKILL.md is missing from that list, the installed binary is older than the skill and the right response is to tell the user to upgrade by re-extracting their newest release tarball over the old one.
 
-If the binary version on disk and the version named in `SKILL.md` (`version:` frontmatter, see the local skill file) disagree, tell the user — the skill might be describing capabilities the binary doesn't have yet (or vice versa). Both should match the version printed by `reolink-cli --version`.
+The skill carries no version of its own — it is distributed with the release archive, so its version is that release. Compare `reolink-cli --version` against the latest release instead. Both should match the version printed by `reolink-cli --version`.
 
 ---
 

--- a/commands/cache-clean.md
+++ b/commands/cache-clean.md
@@ -1,9 +1,13 @@
 ---
-description: Preview + clean artifacts under ~/.cache/reolink older than 7 days
+description: Preview + clean cached artifacts older than 7 days
 argument-hint: [--older-than 30d]
 ---
 
-Clean old cache entries under `~/.cache/reolink/` (snapshots, TTS PCM clips, etc.).
+Clean old cache entries (snapshots, TTS PCM clips, etc.). The cache lives in the
+platform cache directory — `~/.cache/reolink-cli/` on Linux,
+`~/Library/Caches/reolink-cli/` on macOS, `%LOCALAPPDATA%\reolink-cli\cache\` on
+Windows. Run `reolink-cli cache status` to see the resolved path rather than
+assuming one.
 
 **Step 1 — preview (dry-run, always first):**
 

--- a/commands/uninstall.md
+++ b/commands/uninstall.md
@@ -31,7 +31,7 @@ The release tarball ships its own `uninstall.sh` / `uninstall.ps1`. Run them fro
 **Windows — purge:**
 
 ```powershell
-$env:REOLINK_PURGE = "1"; .\uninstall.ps1
+.\uninstall.ps1 --purge
 ```
 
 If the user no longer has the tarball on disk, falling back to manual removal works too:


### PR DESCRIPTION
Closes #12, #13, #14. All three verified against the current tree before fixing.

| Issue | Claim | Verified |
|---|---|---|
| #12 | `/reolink-cli:uninstall` sets `REOLINK_PURGE=1` | `grep REOLINK_PURGE install.ps1` → **0 hits**. The variable was removed in 0.9.1; the slash command was missed. |
| #13 | cache-clean names `~/.cache/reolink/` | `cache status` resolves to `~/Library/Caches/reolink-cli` on macOS. Wrong name *and* wrong platform. |
| #14 | AGENTS.md points at a `version:` frontmatter | `grep -c '^version:' SKILL.md` → **0**. |

Same failure mode each time: documentation asserting something the binary does not do. #12 is the one with teeth — it tells Windows users their credentials were wiped when they were not.