### PR TITLE
Route security reports to GitHub's private advisory flow

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security vulnerability
-    url: https://support.reolink.com
-    about: Do not open a public issue. Report privately — see SECURITY.md.
+    url: https://github.com/reolink/reolink-cli/security/advisories/new
+    about: Do not open a public issue. Report privately — visible only to maintainers.
   - name: Camera or account help (not this tool)
     url: https://support.reolink.com
     about: Firmware, warranty, app or account questions belong with Reolink support.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,9 +5,16 @@
 Please report security issues **privately** — do not open a public issue, and
 do not describe the problem in a pull request.
 
-Contact [Reolink support](https://support.reolink.com) and state that the report
-concerns a **security issue in `reolink-cli`**, so it is routed rather than
-handled as a normal support ticket.
+Use GitHub's private reporting:
+**[Report a vulnerability](https://github.com/reolink/reolink-cli/security/advisories/new)**
+(also reachable from the repository's Security tab). The report is visible only
+to maintainers, and the discussion stays on the advisory until a fix ships.
+
+If that page is unavailable to you, contact
+[Reolink support](https://support.reolink.com) and state that the report
+concerns a **security issue in `reolink-cli`** so it is routed rather than
+handled as a normal support ticket. Be aware that this is a consumer support
+queue with no category for software vulnerabilities — prefer the link above.
 
 Include the version (`reolink-cli --version`), your platform, and the smallest
 steps that reproduce the problem.


### PR DESCRIPTION
Closes #15, #20.

## #15 — reproduced, fixed, verified with real PowerShell

The old pipeline, run under PowerShell 7.6.4 with nothing to find:

```
>>> pipeline finished, script carried on
>>> bin contains: 0 files
exit code: 0
```

After the fix, same input: `reolink-cli.exe not found in the archive`. Normal path still copies both binaries, and the file re-parses clean via `[Parser]::ParseFile`.

**Scope note:** the installer *inside* the release archive is a different script (359 lines vs 101) and was already correct — it uses `Test-Path` and `exit 1`. Only the one-line curl installer in this repository had the gap. I checked rather than assuming they shared code.

## #20 — routed to the private advisory flow

Both `SECURITY.md` and the issue-template contact link sent vulnerability reports to the consumer support portal, which has no category for a software vulnerability. Both now point at `security/advisories/new` (verified reachable). The support portal is kept as a fallback with its limitation **stated rather than hidden**, since a reader who cannot use GitHub still needs somewhere to go.

⚠️ **This PR does not enable Private Vulnerability Reporting.** `GET /repos/.../private-vulnerability-reporting` still returns `{"enabled": false}` — that is an admin-only setting. Until a maintainer flips it (Settings → Advanced Security), the link shows researchers a page they cannot submit from. **Merging without that toggle points the docs somewhere non-functional.**