### PR TITLE
install.ps1: fail by name when the archive is missing a binary

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -66,8 +66,17 @@ try {
   Get-Process -Name reolink-gateway,reolink-cli -ErrorAction SilentlyContinue |
     Where-Object { $_.Path -like (Join-Path $Bin '*') } |
     ForEach-Object { Write-Host "stopping $($_.Name) (pid $($_.Id))"; Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue }
-  Get-ChildItem -Path $tmp -Recurse -Filter 'reolink-cli.exe'     | Select-Object -First 1 | ForEach-Object { Copy-Item $_.FullName (Join-Path $Bin 'reolink-cli.exe') -Force }
-  Get-ChildItem -Path $tmp -Recurse -Filter 'reolink-gateway.exe' | Select-Object -First 1 | ForEach-Object { Copy-Item $_.FullName (Join-Path $Bin 'reolink-gateway.exe') -Force }
+  # Resolve each binary first and fail by name when it is absent. Piping
+  # Get-ChildItem straight into Copy-Item silently does nothing on an empty
+  # pipeline, so a malformed archive used to install nothing, exit 0, and only
+  # surface later as `config init` failing to find a file it never mentions.
+  # install.sh has always failed loudly here; this is the missing half.
+  foreach ($exe in 'reolink-cli.exe', 'reolink-gateway.exe') {
+    $src = Get-ChildItem -Path $tmp -Recurse -Filter $exe -ErrorAction SilentlyContinue |
+           Select-Object -First 1
+    if (-not $src) { throw "$exe not found in the archive" }
+    Copy-Item $src.FullName (Join-Path $Bin $exe) -Force
+  }
 } finally {
   Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
 }


### PR DESCRIPTION
Closes #15. Split out of #23 so it does not wait on the admin-only toggle that half needs.

Reproduced under PowerShell 7.6.4 — old pipeline with nothing to find exits **0** with an empty `bin/`. After the fix, same input throws `reolink-cli.exe not found in the archive`. Normal path still copies both; the file re-parses clean via `[Parser]::ParseFile`.

**Scope note:** the installer inside the release archive is a different script (359 lines vs 101) and was already correct — `Test-Path` + `exit 1`. I checked rather than assuming they shared code; only this one had the gap.