### PR TITLE
release: 0.10.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "reolink-cli",
       "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "source": "./",
       "author": {
         "name": "Reolink"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "author": {
     "name": "reolink"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Plugin for operating Reolink cameras through the local CLI.",
   "author": {
     "name": "Reolink"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "reolink-cli",
   "displayName": "Reolink CLI",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "author": {
     "name": "Reolink"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to the public `reolink-cli` distribution are documented here
 This is the customer-facing release history; it tracks the LAN-only (external)
 builds published as GitHub Releases.
 
+## [0.10.3] — 2026-07-30
+
+Came from an issue opened here.
+
+### Fixed
+
+- **`device expand` failed on an NVR that declines `GetSupport`** (#25). An
+  RLN8-410 on firmware v3.6.5.562 answers cmd 199 with code 300, which aborted
+  the whole command.
+
+  Following that report turned up a second, quieter bug: **even when 199
+  succeeded, the channels written were wrong.** `channelNum` is a *count*, and
+  the code registered `0..count`. The reporter's four cameras sit on channels
+  1, 9, 10 and 11 — so on a cooperative NVR it would have created four entries
+  pointing at slots 0–3, three of them empty.
+
+  `expand` now asks 199 for an upper bound when it answers, ignores it when it
+  does not, then probes each channel and registers only the ones that answer,
+  with their real channel number. The probe uses cmd 44 (OSD get), which is
+  per-channel and refused on an empty slot.
+
+  The probe runs on **one** connection. The channel travels in each request's
+  extension XML rather than in the session, so a single connection can ask
+  about every channel. Opening a session per channel would hold one TCP
+  connection per candidate — the gateway pools sessions with a 300-second TTL
+  and reaps them lazily — and an NVR that caps concurrent connections would
+  start refusing partway through, silently reporting the rest as empty. That
+  would produce a short, confident, wrong channel list: worse than the hard
+  failure it replaced. Measured after scanning 20 channels: 1 established
+  connection to the device.
+
+  Not verified: no RLN8-410 here. The single-connection property and the
+  single-camera refusal are verified on hardware; the non-contiguous channel
+  path is sound in logic and untested in fact.
+
 ## [0.10.2] — 2026-07-29
 
 Both changes came from issues opened here.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **A local-first command-line tool for operating Reolink cameras — JSON by default, with a built-in MCP server and a cross-agent skill so AI agents drive the same core.**
 
-![version](https://img.shields.io/badge/version-0.10.2-blue)
+![version](https://img.shields.io/badge/version-0.10.3-blue)
 ![platform](https://img.shields.io/badge/platform-macOS%20·%20Linux%20·%20Windows-lightgrey)
 ![build](https://img.shields.io/badge/build-external%20·%20LAN--only-green)
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "contextFileName": "GEMINI.md"
 }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "reolink-cli",
   "name": "Reolink CLI",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "author": {
     "name": "Reolink"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "type": "module",
   "description": "Operate Reolink cameras locally via reolink-cli.",
   "main": ".opencode/plugins/reolink-cli.js",

--- a/skills/reolink-cli/references/setup.md
+++ b/skills/reolink-cli/references/setup.md
@@ -27,7 +27,7 @@ tar -xzf "$tmp"/*.tar.gz -C "$tmp"
 cp "$tmp"/*/bin/reolink-cli "$tmp"/*/bin/reolink-gateway "$BIN/"
 chmod +x "$BIN/reolink-cli" "$BIN/reolink-gateway"; rm -rf "$tmp"
 case ":$PATH:" in *":$BIN:"*) ;; *) echo "NOTE: add $BIN to your PATH";; esac
-reolink-cli --version   # → 0.10.2 (external · LAN-only)
+reolink-cli --version   # → 0.10.3 (external · LAN-only)
 ```
 
 Windows: download the `...-windows-x86_64.zip` from the Releases page and put


### PR DESCRIPTION
Publishes the 0.10.3 release: `device expand` now probes each channel instead of trusting `GetSupport` (#25), and the nine version strings move to 0.10.3.

`./scripts/check-version-sync.sh 0.10.3` passes on all nine locations.