### PR TITLE
check-version-sync: add --set to rewrite all nine locations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,15 +30,22 @@ you want. We implement it upstream and it arrives in the next release.
 - **Keep manifests in step.** The version appears in nine places — seven
   manifests, the README badge, and `skills/reolink-cli/references/setup.md` —
   plus a CHANGELOG heading. They must all agree with the published release. Do
-  not hand-edit a version to something no release uses. Check with:
+  not hand-edit a version to something no release uses.
 
   ```bash
-  ./scripts/check-version-sync.sh
+  ./scripts/check-version-sync.sh              # do they agree with the latest release?
+  ./scripts/check-version-sync.sh --set 0.11.0 # rewrite all nine, then check
   ```
 
-  Doing this by hand has failed twice: once the plugin manifests were left
+  Doing this by hand has failed three times: once the plugin manifests were left
   behind, once the whole repository stayed a version back while the release was
-  already published, so readers saw a stale badge over a newer download.
+  already published — readers saw a stale badge over a newer download — and once
+  more while cutting 0.10.3. Use `--set`; it writes every location from one list
+  and then checks its own work, so a location it could not match is reported
+  rather than skipped.
+
+  `--set` does not touch `CHANGELOG.md`. That entry needs release notes a script
+  cannot write, so the check reports it as missing until you write it.
 - **Never commit real data.** No camera passwords, tokens, UIDs, serial
   numbers, private IPs, or footage — in code, docs, examples or screenshots.
   Use placeholders such as `192.168.1.42` and `<camera-password>`.

--- a/scripts/check-version-sync.sh
+++ b/scripts/check-version-sync.sh
@@ -1,28 +1,123 @@
 #!/bin/sh
-# Check that every version string in this repository agrees with the latest
-# published GitHub release.
+# Check — or set — every version string in this repository.
 #
-#   ./scripts/check-version-sync.sh            # compare against the latest release
-#   ./scripts/check-version-sync.sh 0.10.1     # compare against a version you name
+#   ./scripts/check-version-sync.sh              # compare against the latest release
+#   ./scripts/check-version-sync.sh 0.10.1       # compare against a version you name
+#   ./scripts/check-version-sync.sh --set 0.11.0 # rewrite all of them, then check
 #
 # Exits non-zero and lists every file that disagrees.
 #
 # Why this exists: the version appears in nine places, and keeping them in step
-# by hand failed twice in a row — once leaving the plugin manifests behind, once
+# by hand has failed three times — once leaving the plugin manifests behind, once
 # leaving this entire repository on the previous version while the release was
-# already published. Readers saw a 0.10.0 badge over a 0.10.1 download. Checking
-# is cheap; remembering is not.
+# already published, and once more while cutting 0.10.3. Readers saw a 0.10.0
+# badge over a 0.10.1 download. Checking is cheap; remembering is not.
+#
+# --set writes the files, then falls through to the check, so the check is the
+# verdict on its own work: a location whose pattern no longer matches shows up as
+# a MISMATCH rather than being silently skipped. That is the whole point — the
+# failure this script exists to prevent is a location quietly left behind.
+#
+# --set deliberately does NOT touch CHANGELOG.md. The entry needs release notes a
+# script cannot write; the check only asserts the heading exists.
 set -eu
 
 cd "$(dirname "$0")/.."
 
-want="${1:-}"
+usage() {
+  sed -n '2,8p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+mode=check
+want=""
+for arg in "$@"; do
+  case "$arg" in
+    --set)     mode=set ;;
+    -h|--help) usage 0 ;;
+    -*)        echo "unknown option: $arg" >&2; usage 2 ;;
+    *)         want="$arg" ;;
+  esac
+done
+
+# --set never resolves the version from the published release: you run it while
+# preparing a version that is not published yet, and silently stamping whatever
+# is currently latest is how you ship the previous version's number.
+if [ "$mode" = set ]; then
+  [ -n "$want" ] || { echo "--set needs the version to write, e.g. --set 0.11.0" >&2; exit 2; }
+fi
+
+# Exactly three numeric segments. A looser test accepts a typo like "0.10.3.1"
+# and --set would then stamp it into all nine files without complaint.
+if [ -n "$want" ]; then
+  _rest=${want#*.}
+  # Two dots exactly. Without this, "1.2" parses as major=1 minor=2 patch=2 —
+  # every segment numeric, silently accepted, and stamped everywhere as "1.2".
+  case "$_rest" in *.*) ;; *) echo "not a version: $want (expected X.Y.Z)" >&2; exit 2 ;; esac
+  _major=${want%%.*} _minor=${_rest%%.*} _patch=${_rest#*.}
+  for _seg in "$_major" "$_minor" "$_patch"; do
+    case "$_seg" in
+      ''|*[!0-9]*) echo "not a version: $want (expected X.Y.Z)" >&2; exit 2 ;;
+    esac
+  done
+fi
+
 if [ -z "$want" ]; then
   want=$(curl -fsSL -A version-sync-check \
     "https://api.github.com/repos/reolink/reolink-cli/releases/latest" \
     | sed -n 's/.*"tag_name":[[:space:]]*"v\{0,1\}\([^"]*\)".*/\1/p' | head -n1)
   [ -n "$want" ] || { echo "could not resolve the latest release; pass a version explicitly" >&2; exit 2; }
   echo "latest published release: $want"
+fi
+
+# The single list of locations. Adding a tenth is one line here, and both the
+# check and the rewrite pick it up — two lists that must agree is the same class
+# of bug this script exists to catch.
+#
+# Kinds: json   — a manifest with a "version" field (marketplace.json nests it
+#                 inside a plugin entry, so take the first match rather than
+#                 assuming a fixed depth)
+#        badge  — the README shields.io version badge
+#        setup  — the `--version` example output in the skill's setup notes
+LOCATIONS='
+package.json:json
+openclaw.plugin.json:json
+gemini-extension.json:json
+.claude-plugin/plugin.json:json
+.claude-plugin/marketplace.json:json
+.codex-plugin/plugin.json:json
+.cursor-plugin/plugin.json:json
+README.md:badge
+skills/reolink-cli/references/setup.md:setup
+'
+
+extract() { # file kind
+  case "$2" in
+    json)  sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([0-9][^"]*\)".*/\1/p' "$1" | head -n1 ;;
+    badge) sed -n 's/.*version-\([0-9][0-9.]*\)-blue.*/\1/p'                      "$1" | head -n1 ;;
+    setup) sed -n 's/.*reolink-cli --version.*# *→ *\([0-9][0-9.]*\).*/\1/p'      "$1" | head -n1 ;;
+  esac
+}
+
+# Rewrite the FIRST match only. `1,/pat/s///` is the POSIX idiom for that: a bare
+# s/// would also rewrite a pinned dependency that happens to share the version.
+rewrite() { # file kind version
+  case "$2" in
+    json)  sed "1,/\"version\"/s/\"version\"\([[:space:]]*\):\([[:space:]]*\)\"[0-9][^\"]*\"/\"version\"\1:\2\"$3\"/" "$1" > "$1.tmp" ;;
+    badge) sed "1,/version-[0-9]/s/version-[0-9][0-9.]*-blue/version-$3-blue/"                                        "$1" > "$1.tmp" ;;
+    setup) sed "1,/reolink-cli --version/s/\(reolink-cli --version.*# *→ *\)[0-9][0-9.]*/\1$3/"                        "$1" > "$1.tmp" ;;
+  esac
+  mv "$1.tmp" "$1"
+}
+
+if [ "$mode" = set ]; then
+  echo "setting every version string to $want"
+  for entry in $LOCATIONS; do
+    f=${entry%:*}; kind=${entry#*:}
+    [ -f "$f" ] || { printf '  skip      %-46s not in this checkout\n' "$f"; continue; }
+    rewrite "$f" "$kind" "$want"
+  done
+  echo
 fi
 
 fail=0
@@ -36,22 +131,11 @@ report() {
   fi
 }
 
-# The JSON manifests each carry a "version" field. marketplace.json nests it
-# inside a plugin entry, so take the first match in every file rather than
-# assuming a fixed depth.
-for f in package.json openclaw.plugin.json gemini-extension.json \
-         .claude-plugin/plugin.json .claude-plugin/marketplace.json \
-         .codex-plugin/plugin.json .cursor-plugin/plugin.json; do
+for entry in $LOCATIONS; do
+  f=${entry%:*}; kind=${entry#*:}
   [ -f "$f" ] || continue
-  report "$f" "$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([0-9][^"]*\)".*/\1/p' "$f" | head -n1)"
+  report "$f" "$(extract "$f" "$kind")"
 done
-
-report "README.md (badge)" \
-  "$(sed -n 's/.*version-\([0-9][0-9.]*\)-blue.*/\1/p' README.md | head -n1)"
-
-report "skills/reolink-cli/references/setup.md" \
-  "$(sed -n 's/.*reolink-cli --version.*# *→ *\([0-9][0-9.]*\).*/\1/p' \
-     skills/reolink-cli/references/setup.md | head -n1)"
 
 # The changelog is the one place the version must appear as a heading. A release
 # published without its entry is how a user ends up reading last version's notes.
@@ -60,13 +144,13 @@ report "skills/reolink-cli/references/setup.md" \
 if grep -qE "^## \[?${want}\]? " CHANGELOG.md || grep -qE "^## \[?${want}\]?$" CHANGELOG.md; then
   printf '  ok        %-46s has an entry\n' "CHANGELOG.md"
 else
-  printf '  MISMATCH  %-46s no "## [%s]" heading\n' "CHANGELOG.md" "$want"
+  printf '  MISMATCH  %-46s no "## [%s]" heading (write it by hand)\n' "CHANGELOG.md" "$want"
   fail=1
 fi
 
 if [ "$fail" -ne 0 ]; then
   echo
-  echo "Version strings disagree with the published release."
+  echo "Version strings disagree with $want."
   exit 1
 fi
 echo


### PR DESCRIPTION
Closes half of #7 — the `set-version.sh` half. The CI half is a decision for the repo owners; see below.

## What changed

`check-version-sync.sh` gained `--set <version>`, which rewrites all nine locations:

```console
$ ./scripts/check-version-sync.sh --set 0.11.0
setting every version string to 0.11.0

  ok        package.json                                   0.11.0
  ok        openclaw.plugin.json                           0.11.0
  ok        gemini-extension.json                          0.11.0
  ok        .claude-plugin/plugin.json                     0.11.0
  ok        .claude-plugin/marketplace.json                0.11.0
  ok        .codex-plugin/plugin.json                      0.11.0
  ok        .cursor-plugin/plugin.json                     0.11.0
  ok        README.md                                      0.11.0
  ok        skills/reolink-cli/references/setup.md         0.11.0
  MISMATCH  CHANGELOG.md                                   no "## [0.11.0]" heading (write it by hand)
```

## Why it went in the existing script rather than a new `set-version.sh`

The issue asks for the file list to live in "a single list inside the script". Two scripts means two lists that must agree — the same failure class the whole issue is about. So there is one `LOCATIONS` list and both the check and the rewrite read it. Adding a tenth location is still one line.

## `--set` checks its own work

After writing, it falls through to the check rather than reporting success on its own. That matters for the one way a rewrite can fail quietly: a file whose pattern drifted. Verified by deleting the README badge line and running `--set`:

```
MISMATCH  README.md    <not found> (want 9.9.9)
```

Silently skipping there would be worse than not having the script — you would believe nine files were bumped when eight were.

## `--set` will not resolve the version from the release

It requires an explicit `X.Y.Z`. You run it while preparing a version that is *not* published yet; stamping "whatever is latest" is how you ship the previous number.

Version validation is exactly three numeric segments. Both of these were accepted by looser drafts before I tightened it, and either would have been stamped into all nine files without complaint:

| input | result |
|---|---|
| `1.2` | rejected (parsed as major=1 minor=2 patch=2 by the first draft) |
| `1.2.3.4` | rejected |
| `v1.2.3` | rejected |
| `0.11.0` | accepted |

## Tested

On a scratch copy of this repo: all nine rewritten and independently re-grepped; all seven JSON manifests still parse under `python3 -m json.tool`; running `--set` twice leaves the files byte-identical; the check against the real repo still passes for the published 0.10.3.

## The CI half is deliberately not here

A workflow is the only thing that catches the failure mode the issue actually names — *"a release ships and nobody touches this repo at all."* A local script does not, because it only helps when someone remembers to run it.

I am not adding it in this PR because it would be this repository's first GitHub Actions workflow, which is a supply-chain decision for the repo owners rather than something to slip in alongside a shell script. Leaving #7 open for that.

Two things I looked at and rejected rather than leave unmentioned:

- **A version gate in the upstream packaging script.** Builds happen *before* this repo is synced, so it would fire on every legitimate release. A gate that cries wolf gets ignored, which is worse than no gate.
- **A `release.sh` owning the whole publish flow.** It would have to wrap release creation, deletion of superseded releases, and cross-account PRs — irreversible, outward-facing steps that should stay deliberate.
