### PR TITLE
release: 0.10.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "reolink-cli",
       "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "source": "./",
       "author": {
         "name": "Reolink"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "author": {
     "name": "reolink"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Plugin for operating Reolink cameras through the local CLI.",
   "author": {
     "name": "Reolink"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "reolink-cli",
   "displayName": "Reolink CLI",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "author": {
     "name": "Reolink"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,54 @@ All notable changes to the public `reolink-cli` distribution are documented here
 This is the customer-facing release history; it tracks the LAN-only (external)
 builds published as GitHub Releases.
 
+## [0.10.4] — 2026-07-30
+
+Four fixes found by installing 0.10.3 and running it against real hardware. The
+first is 0.10.3's own.
+
+### Fixed
+
+- **`device expand` named child cameras after the wrong channel.** The `channel`
+  field was correct; the names were not. Defaults and descriptions used the
+  position in the discovered list rather than the real channel number. On the
+  NVR from #25 — cameras on channels 1, 9, 10 and 11 — that produces `nvr-ch0`
+  through `nvr-ch3`, four aliases each claiming a channel it does not connect to.
+
+  Nothing fails loudly, which is what makes it bad: you find out by wondering
+  why `nvr-ch1` shows the wrong camera. It was 0.10.3's fix left half-done — the
+  probe learned the real channel numbers and the naming never used them.
+
+  Non-contiguous-channel hardware is not something I have, so this is pinned by
+  three unit tests rather than one hand-check.
+
+- **`reolink-gateway --help`, `--version` and `--addr` all failed with
+  "invalid socket address".** The binary took `args[1]` as the listen address,
+  so any flag was handed to `bind()` and the error pointed at something entirely
+  unrelated to the real problem. Unrecognised arguments are now rejected by name;
+  `--addr` and the bare positional form both work (`reolink-cli gateway start`
+  uses the positional one). `reolink-gateway --version` also reports the build
+  flavor now, the same way the CLI does.
+
+- **The CLI could hang forever talking to the gateway.** If something occupies
+  the gateway port and accepts the connection without answering, the control
+  channel had no timeout: no output, no exit, indefinitely — and an AI agent
+  driving the CLI wedges with it. Docker and OrbStack both listen on `:9000` by
+  default, the port this tool documents, so it is easy to land in. There is now
+  a 60-second bound on the control channel with an error naming the likely
+  cause. Preview and VOD share the underlying read path and stay unbounded on
+  purpose.
+
+- **The channel scan had no overall budget.** Per-request I/O timeouts (10s) add
+  up once a device stops answering mid-scan. The scan is capped at 30 seconds
+  total and reports how far it got (`scanned` / `requested`), so a truncated
+  scan reads as "checked 6 of 20" instead of looking like a complete answer.
+
+### Added
+
+- **`./scripts/check-version-sync.sh --set <version>`** rewrites all nine version
+  locations from one list, then re-checks its own work so a location whose
+  pattern drifted is reported rather than skipped (#7, #27).
+
 ## [0.10.3] — 2026-07-30
 
 Came from an issue opened here.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **A local-first command-line tool for operating Reolink cameras — JSON by default, with a built-in MCP server and a cross-agent skill so AI agents drive the same core.**
 
-![version](https://img.shields.io/badge/version-0.10.3-blue)
+![version](https://img.shields.io/badge/version-0.10.4-blue)
 ![platform](https://img.shields.io/badge/platform-macOS%20·%20Linux%20·%20Windows-lightgrey)
 ![build](https://img.shields.io/badge/build-external%20·%20LAN--only-green)
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "contextFileName": "GEMINI.md"
 }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "reolink-cli",
   "name": "Reolink CLI",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "author": {
     "name": "Reolink"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "type": "module",
   "description": "Operate Reolink cameras locally via reolink-cli.",
   "main": ".opencode/plugins/reolink-cli.js",

--- a/skills/reolink-cli/references/setup.md
+++ b/skills/reolink-cli/references/setup.md
@@ -27,7 +27,7 @@ tar -xzf "$tmp"/*.tar.gz -C "$tmp"
 cp "$tmp"/*/bin/reolink-cli "$tmp"/*/bin/reolink-gateway "$BIN/"
 chmod +x "$BIN/reolink-cli" "$BIN/reolink-gateway"; rm -rf "$tmp"
 case ":$PATH:" in *":$BIN:"*) ;; *) echo "NOTE: add $BIN to your PATH";; esac
-reolink-cli --version   # → 0.10.3 (external · LAN-only)
+reolink-cli --version   # → 0.10.4 (external · LAN-only)
 ```
 
 Windows: download the `...-windows-x86_64.zip` from the Releases page and put


### PR DESCRIPTION
Publishes 0.10.4: four fixes found by installing 0.10.3 and running it against real hardware, the first being 0.10.3's own `device expand` naming bug.

Version strings bumped with the `--set` mode from #27 — its first real use. One command instead of nine hand-edits, and the CHANGELOG was correctly reported as missing until written by hand.

`./scripts/check-version-sync.sh` passes against the published release.