### PR TITLE
fix: scope the uninstall fallback pkill to the install prefix

### DIFF
--- a/commands/uninstall.md
+++ b/commands/uninstall.md
@@ -37,8 +37,9 @@ The release tarball ships its own `uninstall.sh` / `uninstall.ps1`. Run them fro
 If the user no longer has the tarball on disk, falling back to manual removal works too:
 
 ```bash
-# macOS / Linux
-pkill -f reolink-gateway
+# macOS / Linux — kill only the gateway from this install prefix,
+# never gateways belonging to another installation
+pkill -f "$HOME/.local/bin/reolink-gateway"
 rm -f ~/.local/bin/reolink-cli ~/.local/bin/reolink-gateway
 # (purge only)
 rm -rf ~/.config/reolink-cli ~/.cache/reolink-cli ~/.local/state/reolink-cli


### PR DESCRIPTION
## What changes

Fixes #29. The manual fallback in `commands/uninstall.md` ran `pkill -f reolink-gateway`, which matches the full command line of every process on the machine — killing gateways from other installations (the over-reach 0.9.1 fixed inside `setup --uninstall`) and any unrelated process whose command line contains the string. #22 fixed the `REOLINK_PURGE` half of #12; this is the remaining half. The kill is now scoped to the same `~/.local/bin` prefix whose binaries the fallback removes.

## How it was verified

Behavioral claim checked against `pkill(1)` semantics: `-f` matches the full argument list, so the full-path pattern only matches a gateway started from `$HOME/.local/bin/`. Doc-only change; no camera interaction involved.

## Checklist

- [x] No password, camera UID, or private network address appears in the diff
- [x] Docs updated if a flag, output field, or default changed
- [ ] `cargo test --workspace` passes — N/A: this repo contains no Rust source; slash-command doc only
