### PR TITLE
fix: drop the dangling sentence left by the AGENTS.md Part 5 rewrite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,7 @@ reolink-cli cache status --output json 2>/dev/null \
 
 **Read `.data.commands`** from the `features` output before dispatching any subcommand. If a command in SKILL.md is missing from that list, the installed binary is older than the skill and the right response is to tell the user to upgrade by re-extracting their newest release tarball over the old one.
 
-The skill carries no version of its own — it is distributed with the release archive, so its version is that release. Compare `reolink-cli --version` against the latest release instead. Both should match the version printed by `reolink-cli --version`.
+The skill carries no version of its own — it is distributed with the release archive, so its version is that release. Compare `reolink-cli --version` against the latest release instead.
 
 ---
 


### PR DESCRIPTION
## What changes

Fixes #30. The AGENTS.md Part 5 rewrite in #22 kept the closing sentence of the text it replaced — "Both should match the version printed by `reolink-cli --version`." — whose "both" (binary version + the nonexistent `version:` frontmatter) no longer exists. After the rewrite it reduces to "`--version` should match `--version`". The preceding sentence already states the whole check, so the leftover is deleted.

## How it was verified

Read in context: the paragraph now ends at "Compare `reolink-cli --version` against the latest release instead.", which is complete and actionable on its own. Doc-only, one line removed.

## Checklist

- [x] No password, camera UID, or private network address appears in the diff
- [x] Docs updated if a flag, output field, or default changed
- [ ] `cargo test --workspace` passes — N/A: this repo contains no Rust source; docs only
