### PR TITLE
release: 0.10.5, and a --self mode for the version check

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "reolink-cli",
       "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "source": "./",
       "author": {
         "name": "Reolink"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "author": {
     "name": "reolink"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Plugin for operating Reolink cameras through the local CLI.",
   "author": {
     "name": "Reolink"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "reolink-cli",
   "displayName": "Reolink CLI",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "author": {
     "name": "Reolink"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,52 @@ All notable changes to the public `reolink-cli` distribution are documented here
 This is the customer-facing release history; it tracks the LAN-only (external)
 builds published as GitHub Releases.
 
+## [0.10.5] — 2026-07-30
+
+### Fixed
+
+- **`setup --uninstall` did not stop your own gateway on macOS**, then deleted
+  the binary out from under it, leaving a process running a file that no longer
+  exists.
+
+  This came out of a contributor report (#29, #31) about the docs' manual
+  `pkill -f reolink-gateway` fallback matching every install on the machine. The
+  same mistake was one layer down in the code, and worse there:
+  `process_exe_path` used `ps -p <pid> -o comm=` on non-Linux platforms under a
+  comment asserting that prints the executable's full path. It does not — it
+  echoes argv[0], so a gateway started as `reolink-gateway` from `PATH` reported
+  a bare name, which the ownership check rejects as non-absolute. That comment
+  had never been executed.
+
+  The question is now asked backwards: `lsof -t -a -d txt <prefix>/bin/reolink-gateway`
+  lists the processes whose *executing image* is that file, which avoids argv
+  entirely. `-d txt` restricts it to the image, so a process merely reading the
+  binary is not a candidate. Linux keeps `/proc/<pid>/exe`.
+
+  Verified with two gateways from different prefixes, one started by bare name:
+  ours was stopped, the second install was left alone.
+
+### Verified
+
+- **`device expand` now has hardware behind it on the firmware from #25.** An
+  RLN4E running v3.6.5.562 — the same version as the RLN8-410 in that report —
+  confirms the original bug (cmd 199 answers code 300) and the fix: the channel
+  with a camera answers, empty channels are refused, and scanning 20 channels
+  takes 0.9 seconds.
+
+  The channel field genuinely selects the channel, which is worth stating on its
+  own: a protocol that ignored it would look identical on a one-camera device,
+  with every channel returning channel 0's data.
+
+  Correction to a note in #25 along the way: on an NVR with no cameras attached,
+  cmd 44 is refused on *every* channel, which briefly read as the firmware not
+  implementing it. It does. The refusal means "no camera on that channel" —
+  exactly the signal the probe wants.
+
+  Non-contiguous numbering is covered by an integration test reproducing the
+  reporter's device. Reverting the naming to the 0.10.3 behaviour makes it fail,
+  which is the only reason to believe it guards anything.
+
 ## [0.10.4] — 2026-07-30
 
 Four fixes found by installing 0.10.3 and running it against real hardware. The

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ you want. We implement it upstream and it arrives in the next release.
 
   ```bash
   ./scripts/check-version-sync.sh              # do they agree with the latest release?
+  ./scripts/check-version-sync.sh --self       # do they agree with each other?
   ./scripts/check-version-sync.sh --set 0.11.0 # rewrite all nine, then check
   ```
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **A local-first command-line tool for operating Reolink cameras — JSON by default, with a built-in MCP server and a cross-agent skill so AI agents drive the same core.**
 
-![version](https://img.shields.io/badge/version-0.10.4-blue)
+![version](https://img.shields.io/badge/version-0.10.5-blue)
 ![platform](https://img.shields.io/badge/platform-macOS%20·%20Linux%20·%20Windows-lightgrey)
 ![build](https://img.shields.io/badge/build-external%20·%20LAN--only-green)
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "contextFileName": "GEMINI.md"
 }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "reolink-cli",
   "name": "Reolink CLI",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "author": {
     "name": "Reolink"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "type": "module",
   "description": "Operate Reolink cameras locally via reolink-cli.",
   "main": ".opencode/plugins/reolink-cli.js",

--- a/scripts/check-version-sync.sh
+++ b/scripts/check-version-sync.sh
@@ -3,6 +3,7 @@
 #
 #   ./scripts/check-version-sync.sh              # compare against the latest release
 #   ./scripts/check-version-sync.sh 0.10.1       # compare against a version you name
+#   ./scripts/check-version-sync.sh --self       # only: do the nine agree with each other?
 #   ./scripts/check-version-sync.sh --set 0.11.0 # rewrite all of them, then check
 #
 # Exits non-zero and lists every file that disagrees.
@@ -31,14 +32,29 @@ usage() {
 
 mode=check
 want=""
+self=0
 for arg in "$@"; do
   case "$arg" in
     --set)     mode=set ;;
+    --self)    self=1 ;;
     -h|--help) usage 0 ;;
     -*)        echo "unknown option: $arg" >&2; usage 2 ;;
     *)         want="$arg" ;;
   esac
 done
+
+# --self asks only "do these nine agree with each other?", taking package.json as
+# the reference. It exists for pull requests: a branch may legitimately carry a
+# version no release uses yet, but a hand-edit that updates eight of nine files
+# is never legitimate. Comparing against the published release is the separate
+# check, and it belongs on `release: published` and a schedule.
+if [ "$self" -eq 1 ]; then
+  [ -z "$want" ] || { echo "--self takes no version argument" >&2; exit 2; }
+  [ "$mode" = check ] || { echo "--self cannot be combined with --set" >&2; exit 2; }
+  want=$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([0-9][^"]*\)".*/\1/p' package.json | head -n1)
+  [ -n "$want" ] || { echo "could not read a version from package.json" >&2; exit 2; }
+  echo "checking internal agreement against package.json: $want"
+fi
 
 # --set never resolves the version from the published release: you run it while
 # preparing a version that is not published yet, and silently stamping whatever

--- a/skills/reolink-cli/references/setup.md
+++ b/skills/reolink-cli/references/setup.md
@@ -27,7 +27,7 @@ tar -xzf "$tmp"/*.tar.gz -C "$tmp"
 cp "$tmp"/*/bin/reolink-cli "$tmp"/*/bin/reolink-gateway "$BIN/"
 chmod +x "$BIN/reolink-cli" "$BIN/reolink-gateway"; rm -rf "$tmp"
 case ":$PATH:" in *":$BIN:"*) ;; *) echo "NOTE: add $BIN to your PATH";; esac
-reolink-cli --version   # → 0.10.4 (external · LAN-only)
+reolink-cli --version   # → 0.10.5 (external · LAN-only)
 ```
 
 Windows: download the `...-windows-x86_64.zip` from the Releases page and put


### PR DESCRIPTION
Two things: the 0.10.5 sync, and the script groundwork for the CI half of #7.

## 0.10.5

[Release notes](https://github.com/reolink/reolink-cli/releases/tag/v0.10.5). `setup --uninstall` did not stop your own gateway on macOS and then deleted the binary out from under it — the code-level version of the `pkill` over-reach reported in #29 and fixed in the docs by #31. Plus hardware verification of the #25 fix on an RLN4E running the reporter's exact firmware (v3.6.5.562).

Version strings bumped with `--set`, so the nine locations moved in one command and the CHANGELOG was correctly reported as missing until written by hand.

## `--self`

`check-version-sync.sh --self` asks only whether the nine locations agree **with each other**, taking `package.json` as the reference:

```
$ ./scripts/check-version-sync.sh --self
checking internal agreement against package.json: 0.10.5
  ok  package.json  0.10.5
  ...
```

It deliberately does not consult the published release. That is a different question, and a branch may legitimately carry a version no release uses yet — failing pull requests for that would train people to ignore the check.

Verified it reports rather than passes when a manifest drifts:

```
$ sed -i 's/"version": "0.10.5"/"version": "0.9.9"/' .cursor-plugin/plugin.json
$ ./scripts/check-version-sync.sh --self
  MISMATCH  .cursor-plugin/plugin.json    0.9.9 (want 0.10.5)
```

`--self` with a version argument, and `--self --set`, are both refused rather than silently doing something surprising.

## The workflow itself is not in this PR

It was, and I took it out. Pushing `.github/workflows/version-sync.yml` is rejected:

```
! [remote rejected] refusing to allow an OAuth App to create or update workflow
  `.github/workflows/version-sync.yml` without `workflow` scope
```

None of the tokens available to me carry that scope, and the contents API is under the same restriction, so this is not something I can work around — it needs a token authorised for workflows, or the file added through the web UI.

I split it rather than hold the release sync behind it: this repository currently shows a 0.10.4 badge over a 0.10.5 download, which is exactly the failure #7 is about, and there is no reason to leave it there while the CI question is sorted out.

The workflow is written and tested (two mutually exclusive jobs — `--self` on PR/push, the release comparison on `release: published` plus a daily schedule; `permissions: contents: read`; a settle delay so a just-published release does not report a mismatch that fixes itself). It goes in as a follow-up the moment the scope exists.
