### PR TITLE
ci: enforce the version sync (#7)

### DIFF
--- a/.github/workflows/version-sync.yml
+++ b/.github/workflows/version-sync.yml
@@ -1,0 +1,65 @@
+# The version appears in nine places in this repository plus a CHANGELOG
+# heading, and keeping them in step by hand has failed three times — once
+# leaving the plugin manifests behind, once leaving the whole repository a
+# version back while the release was already published (readers saw a 0.10.0
+# badge over a 0.10.1 download), and once more while cutting 0.10.3.
+#
+# `scripts/check-version-sync.sh` catches all of that, but only when somebody
+# runs it. The failure this file exists for is the one where nobody does:
+# a release ships and this repository is never touched.
+#
+# Two different questions, so two different triggers:
+#
+#   --self   do the nine agree with each other?  → every PR and push.
+#            A branch may legitimately carry a version no release uses yet, so
+#            this deliberately does not look at the published release.
+#
+#   (none)   do they agree with the latest published release?  → when a release
+#            is published, on a daily schedule, and on demand. This is the one
+#            that catches "released and forgot".
+#
+# Both call the same script. The workflow stays a thin caller so there is never
+# a second copy of the file list to drift — that duplication is the same bug
+# class the script exists to prevent.
+name: version-sync
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+  schedule:
+    # Daily. A release published without syncing this repository is a stale
+    # badge over a newer download; a day is a reasonable ceiling on how long
+    # that can go unnoticed.
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+# Read-only. This job reports; it never writes to the repository, and the
+# scheduled run reaches the public GitHub API without any credential.
+permissions:
+  contents: read
+
+jobs:
+  agree-with-each-other:
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./scripts/check-version-sync.sh --self
+
+  agree-with-latest-release:
+    if: github.event_name != 'pull_request' && github.event_name != 'push'
+    runs-on: ubuntu-latest
+    steps:
+      # A release's assets appear a moment after the release event fires, and
+      # the sync PR for a release lands after the release itself. Give the
+      # publish flow room rather than reporting a mismatch that fixes itself.
+      - name: Let a just-published release settle
+        if: github.event_name == 'release'
+        run: sleep 300
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - run: ./scripts/check-version-sync.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,11 @@ you want. We implement it upstream and it arrives in the next release.
   ./scripts/check-version-sync.sh --set 0.11.0 # rewrite all nine, then check
   ```
 
+  CI runs `--self` on every pull request, so a hand-edit that updates eight of
+  the nine files fails there. It runs the release comparison on `release:
+  published` and daily — that one catches what a local script cannot, where a
+  release ships and nobody touches this repository at all.
+
   Doing this by hand has failed three times: once the plugin manifests were left
   behind, once the whole repository stayed a version back while the release was
   already published — readers saw a stale badge over a newer download — and once


### PR DESCRIPTION
Closes the CI half of #7. The script half landed in #27 and #33; this is the part that runs it without anyone remembering to.

## Why a workflow at all

A local script only helps when somebody runs it, and the failure #7 actually names is the one where nobody does — *"a release ships and nobody touches this repo at all."* That has happened twice, and readers saw a stale badge over a newer download both times.

## Two questions, two triggers

| trigger | check | catches |
|---|---|---|
| every PR and push | `--self` — do the nine agree with each other? | a hand-edit that updates eight of nine |
| `release: published`, daily, manual | do they agree with the **latest published release**? | released and forgot |

`--self` deliberately does not consult the published release. A branch may legitimately carry a version no release uses yet, and failing pull requests for that would train people to ignore the check — which is how you end up with a check nobody reads.

**Both jobs call `scripts/check-version-sync.sh`.** Putting the file list in the YAML would create a second copy that has to agree with the first, which is the exact bug class this issue is about.

## Details worth defending

- **`permissions: contents: read`.** The job reports; it never writes. The scheduled run reaches the public GitHub API with no credential at all, so no secret is involved.
- **`sleep 300` before the release comparison.** A release's assets appear a moment after the event fires, and the sync PR lands *after* the release itself. Without the delay every legitimate release would report a mismatch that fixes itself minutes later, and a check that cries wolf gets muted.
- **The two jobs are mutually exclusive**, so any given event runs exactly one. Checked against all five event names.

## Tested

`--self` passes here, and reports rather than passes when a manifest drifts:

```
$ sed -i 's/"version": "0.10.5"/"version": "0.9.9"/' .cursor-plugin/plugin.json
$ ./scripts/check-version-sync.sh --self
  MISMATCH  .cursor-plugin/plugin.json    0.9.9 (want 0.10.5)
```

The `--self` job on this pull request is itself the first live run.

## Note

This is the repository's first GitHub Actions workflow. It was held back from #33 because pushing `.github/workflows/` is rejected for tokens without `workflow` scope, and I did not want the 0.10.5 sync — which was fixing a live stale badge — waiting behind that.
