### PR TITLE
installers: anchor integrity to the repository, not the release; fail closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,8 +287,14 @@ what they do:
 
 - resolve the latest release from the GitHub API, then download that release's
   asset from `github.com` — no other host is contacted
-- **verify the download against the release's `SHA256SUMS` and abort on any
-  mismatch**, missing entry, or missing checksum file
+- **verify the download against `checksums/<tag>.sha256` committed to this
+  repository's default branch**, and abort on any mismatch, missing entry, or
+  missing checksum file — never against the checksum attached to the release
+  itself. A release asset can be replaced by one API call and the attached
+  checksum regenerated with it; a file on the default branch sits behind a
+  reviewed pull request and permanent history. This is an integrity check, not
+  a signature: it moves the anchor out of the release, it does not prove who
+  built the archive.
 - install two binaries to `~/.local/bin` (`%USERPROFILE%\.local\bin` on
   Windows) — **no `sudo`, no system directories, no services**
 - stop a running `reolink-gateway` **only if it runs from that same prefix**,

--- a/checksums/v0.10.5.sha256
+++ b/checksums/v0.10.5.sha256
@@ -1,0 +1,4 @@
+5cbc35047b48bcef4d429b4386e79533ab570f4dc624bf249ce114319b0d4339  reolink-cli-0.10.5-external-darwin-arm64.tar.gz
+76d6f4822ffc7bc4d5c2087b5157220badd0ba20cb3b20a5714b5dcb13f8354b  reolink-cli-0.10.5-external-linux-arm64.tar.gz
+f7c9f353cf8ae13daf7ffce1ce2a2edd81553cafcebe1fbbfc8ea7f4c0a14c1f  reolink-cli-0.10.5-external-linux-x86_64.tar.gz
+8c671a7c977ad087ee8a3055e38ad1cd6fe44256cce2c267dbaaf77537198b5b  reolink-cli-0.10.5-external-windows-x86_64.zip

--- a/install.ps1
+++ b/install.ps1
@@ -31,15 +31,23 @@ try {
   Write-Host "==> downloading $asset ($tag)"
   Invoke-WebRequest -Headers $headers -Uri "https://github.com/$Repo/releases/download/$tag/$asset" -OutFile $zip
 
-  # Verify against the release's published SHA256SUMS before unpacking. This
-  # script installs executables fetched over the network, so an unverified
-  # archive is the weakest link; every release ships SHA256SUMS for this.
-  Write-Host "==> verifying checksum"
-  $sumsPath = Join-Path $tmp "SHA256SUMS"
+  # Verify against the checksums COMMITTED TO THE REPOSITORY, not the
+  # SHA256SUMS attached to the release. A checksum from the same release can
+  # only detect accidental corruption: whoever can replace the asset can
+  # regenerate a matching SHA256SUMS in the same API call. A file on the
+  # default branch is behind a reviewed pull request and permanent history;
+  # checksums/<tag>.sha256 is committed there as part of each release, from
+  # the machine that built it.
+  #
+  # Fail closed: no fallback to the release-attached SHA256SUMS, and a tag
+  # with no committed checksum file aborts — so a fabricated release does
+  # not install. This is an integrity check, not a signature.
+  Write-Host "==> verifying checksum against the repository"
+  $sumsPath = Join-Path $tmp "CHECKSUMS"
   try {
-    Invoke-WebRequest -Headers $headers -Uri "https://github.com/$Repo/releases/download/$tag/SHA256SUMS" -OutFile $sumsPath
+    Invoke-WebRequest -Headers $headers -Uri "https://raw.githubusercontent.com/$Repo/main/checksums/$tag.sha256" -OutFile $sumsPath
   } catch {
-    throw "could not fetch SHA256SUMS for $tag - refusing to install an unverified binary"
+    throw "no committed checksum file for $tag (checksums/$tag.sha256 on the default branch). Either this release has not been synced yet, or the tag did not come from the release process. Refusing to install."
   }
   # Split on whitespace rather than regex-matching the line: the asset name
   # would otherwise be interpolated into a pattern, where one mis-escaped
@@ -52,10 +60,10 @@ try {
       if ($name -eq $asset) { $expected = $parts[0].Trim().ToLower(); break }
     }
   }
-  if (-not $expected) { throw "SHA256SUMS has no entry for $asset - refusing to install" }
+  if (-not $expected) { throw "checksums/$tag.sha256 has no entry for $asset - refusing to install" }
   $actual = (Get-FileHash -Path $zip -Algorithm SHA256).Hash.ToLower()
   if ($actual -ne $expected) {
-    throw "checksum mismatch for $asset`n  expected $expected`n  actual   $actual`nThe download is corrupt or tampered with. Nothing was installed."
+    throw "checksum mismatch for $asset`n  expected $expected`n  actual   $actual`nThe download does not match the checksum committed to the repository. Nothing was installed."
   }
   Write-Host "    ok ($expected)"
 

--- a/install.sh
+++ b/install.sh
@@ -60,32 +60,48 @@ curl -fSL -A reolink-cli-install ${AUTH:+-H "$AUTH"} \
   -o "$tmp/pkg.tar.gz" "https://github.com/$REPO/releases/download/$tag/$asset" \
   || die "download failed — see https://github.com/$REPO/releases"
 
-# Verify the download against the release's published SHA256SUMS before running
-# anything out of it. This script installs executables fetched over the network,
-# so an unverified archive is the weakest link in the chain — every release ships
-# SHA256SUMS for exactly this purpose.
-say "==> verifying checksum"
-if curl -fsSL -A reolink-cli-install ${AUTH:+-H "$AUTH"} \
-     -o "$tmp/SHA256SUMS" "https://github.com/$REPO/releases/download/$tag/SHA256SUMS" 2>/dev/null; then
-  expected=$(sed -n "s/^\([0-9a-f]\{64\}\)[[:space:]]*[*]\{0,1\}$asset$/\1/p" "$tmp/SHA256SUMS" | head -n1)
-  [ -n "$expected" ] || die "SHA256SUMS has no entry for $asset — refusing to install"
+# Verify the download against the checksums COMMITTED TO THE REPOSITORY, not the
+# SHA256SUMS attached to the release. The distinction is the trust boundary:
+# replacing a release asset takes one API call by any account with write access
+# and leaves no visible trace, and whoever can do that can regenerate a matching
+# SHA256SUMS in the same call — a checksum from the same release can therefore
+# only ever detect accidental corruption. A file on the default branch is behind
+# a reviewed pull request and permanent history. checksums/<tag>.sha256 is
+# committed there as part of each release, from the machine that built it.
+#
+# Fail closed, deliberately:
+#   - no fallback to the release-attached SHA256SUMS — a fallback would hand an
+#     attacker who controls the release a way to bypass this by making the
+#     repository fetch fail;
+#   - a tag with no committed checksum file aborts, so a fabricated release
+#     (a tag that never went through the release process) does not install.
+#
+# This is an integrity check, not a signature: it moves the anchor out of the
+# release, it does not prove who built the archive.
+say "==> verifying checksum against the repository"
+curl -fsSL -A reolink-cli-install ${AUTH:+-H "$AUTH"} \
+     -o "$tmp/CHECKSUMS" "https://raw.githubusercontent.com/$REPO/main/checksums/$tag.sha256" 2>/dev/null \
+  || die "no committed checksum file for $tag (checksums/$tag.sha256 on the default branch).
+Either this release has not been synced yet, or the tag did not come from the
+release process. Refusing to install."
 
-  if command -v shasum >/dev/null 2>&1; then
-    actual=$(shasum -a 256 "$tmp/pkg.tar.gz" | awk '{print $1}')
-  elif command -v sha256sum >/dev/null 2>&1; then
-    actual=$(sha256sum "$tmp/pkg.tar.gz" | awk '{print $1}')
-  else
-    die "no shasum/sha256sum available to verify the download — install one, or download and verify manually from https://github.com/$REPO/releases"
-  fi
+expected=$(sed -n "s/^\([0-9a-f]\{64\}\)[[:space:]]*[*]\{0,1\}$asset$/\1/p" "$tmp/CHECKSUMS" | head -n1)
+[ -n "$expected" ] || die "checksums/$tag.sha256 has no entry for $asset — refusing to install"
 
-  [ "$actual" = "$expected" ] || die "checksum mismatch for $asset
+if command -v shasum >/dev/null 2>&1; then
+  actual=$(shasum -a 256 "$tmp/pkg.tar.gz" | awk '{print $1}')
+elif command -v sha256sum >/dev/null 2>&1; then
+  actual=$(sha256sum "$tmp/pkg.tar.gz" | awk '{print $1}')
+else
+  die "no shasum/sha256sum available to verify the download — install one, or download and verify manually from https://github.com/$REPO/releases"
+fi
+
+[ "$actual" = "$expected" ] || die "checksum mismatch for $asset
   expected $expected
   actual   $actual
-The download is corrupt or tampered with. Nothing was installed."
-  say "    ok ($expected)"
-else
-  die "could not fetch SHA256SUMS for $tag — refusing to install an unverified binary"
-fi
+The download does not match the checksum committed to the repository.
+Nothing was installed."
+say "    ok ($expected)"
 
 tar -xzf "$tmp/pkg.tar.gz" -C "$tmp"
 mkdir -p "$BIN"

--- a/scripts/check-version-sync.sh
+++ b/scripts/check-version-sync.sh
@@ -153,6 +153,17 @@ for entry in $LOCATIONS; do
   report "$f" "$(extract "$f" "$kind")"
 done
 
+# The installers verify downloads against checksums/v<version>.sha256 on the
+# default branch and fail closed — so a release synced without its checksum file
+# does not have a stale badge, it has a broken `curl | sh` for every user until
+# someone notices. This check is how someone notices within a day.
+if [ -s "checksums/v${want}.sha256" ]; then
+  printf '  ok        %-46s exists\n' "checksums/v${want}.sha256"
+else
+  printf '  MISMATCH  %-46s missing — one-line installs FAIL CLOSED without it\n' "checksums/v${want}.sha256"
+  fail=1
+fi
+
 # The changelog is the one place the version must appear as a heading. A release
 # published without its entry is how a user ends up reading last version's notes.
 # Anchor the closing bracket: a prefix match would accept "## [0.10.1-rc]"


### PR DESCRIPTION
Reported privately through support; a security advisory with reporter credit follows once coordinated. The finding, in one sentence: the installers verified downloads against a `SHA256SUMS` fetched from the same release as the archive, while the failure message claimed tamper protection — but whoever can replace a release asset can regenerate a matching `SHA256SUMS` in the same API call, so the check could only ever catch accidental corruption.

## What changes

**The integrity anchor moves out of the release trust boundary.** Each release now commits `checksums/<tag>.sha256` to this repository's default branch (from the machine that built the artifacts), and both installers verify against that — never against the release-attached file. The asymmetry that makes this meaningful, verified on this repository's actual settings: replacing a release asset is one API call by any account with write access and leaves no visible trace; changing a file on `main` requires a reviewed pull request and leaves permanent history.

**Fail closed, twice:**

- No fallback to the release-attached `SHA256SUMS`. A fallback would hand an attacker who controls the release a bypass: make the repository fetch fail, and the script walks back into the boundary it was escaping.
- A tag with no committed checksum file aborts. A fabricated release — a tag that never went through the release process — has no file on `main`, so it does not install.

**The wording is corrected.** A mismatch now reads "The download does not match the checksum committed to the repository", not "corrupt or tampered with". The comments state plainly that this is an integrity check, not a signature: it moves the anchor, it does not prove who built the archive.

**`check-version-sync.sh` asserts the checksum file exists** for the version under check. With fail-closed installers, a release synced without its file is not a stale badge — it is a broken `curl | sh` for every user until someone notices. The daily CI run is how someone notices.

`checksums/v0.10.5.sha256` is included for the current release, copied from the build machine's `dist/SHA256SUMS` (and cross-checked against the published assets, which still match).

## What this deliberately does not do

- **No signing (minisign/cosign) yet.** Neither verifier is preinstalled for the audience of a one-line install, which leaves two behaviours: fail without it (breaks the one-line path) or skip without it (unverified in practice plus a claim of signing — the same overstatement this PR removes, relocated). If signing lands later it layers on top of this for users who have a verifier; the two compose.
- **No GitHub attestation.** Strongest option, but requires the build to run in Actions, which it does not today. Tracked.

## Tested

Three paths, against a local server standing in for `raw.githubusercontent.com` (the tested copy differs from the shipped script only in that base URL — diff-verified):

| case | result |
|---|---|
| committed checksum matches | installs; `reolink-cli 0.10.5 (external · LAN-only)` |
| checksum altered (stands in for a replaced asset) | aborts, exit 1, zero files installed |
| no checksum file for the tag (fabricated release / unsynced) | aborts, exit 1, zero files installed |

`sh -n` passes; `./scripts/check-version-sync.sh` passes including the new existence check. `install.ps1` got the same change but no PowerShell run here — same URL, same fail-closed structure, reviewed by eye.

After merge, the real `curl | sh` path from `main` is the final acceptance run.
