### PR TITLE
version copies: nine locations down to seven; badge becomes a live lookup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,19 +27,21 @@ you want. We implement it upstream and it arrives in the next release.
   the docs that had never been executed — a flag that did not exist, a
   subcommand that had been renamed. If you touch an example, run it and paste
   the output in the PR.
-- **Keep manifests in step.** The version appears in nine places — seven
-  manifests, the README badge, and `skills/reolink-cli/references/setup.md` —
-  plus a CHANGELOG heading. They must all agree with the published release. Do
+- **Keep manifests in step.** The version appears in seven manifests, plus a
+  CHANGELOG heading and the release's `checksums/<tag>.sha256`. (It was nine:
+  the README badge is a live shields.io release lookup now, and the skill's
+  example output no longer names a version — copies that cannot go stale
+  beat copies that are checked.) They must all agree with the published release. Do
   not hand-edit a version to something no release uses.
 
   ```bash
   ./scripts/check-version-sync.sh              # do they agree with the latest release?
   ./scripts/check-version-sync.sh --self       # do they agree with each other?
-  ./scripts/check-version-sync.sh --set 0.11.0 # rewrite all nine, then check
+  ./scripts/check-version-sync.sh --set 0.11.0 # rewrite all seven, then check
   ```
 
-  CI runs `--self` on every pull request, so a hand-edit that updates eight of
-  the nine files fails there. It runs the release comparison on `release:
+  CI runs `--self` on every pull request, so a hand-edit that misses one of
+  the manifests fails there. It runs the release comparison on `release:
   published` and daily — that one catches what a local script cannot, where a
   release ships and nobody touches this repository at all.
 
@@ -48,7 +50,8 @@ you want. We implement it upstream and it arrives in the next release.
   already published — readers saw a stale badge over a newer download — and once
   more while cutting 0.10.3. Use `--set`; it writes every location from one list
   and then checks its own work, so a location it could not match is reported
-  rather than skipped.
+  rather than skipped. That history is also why the badge stopped being a copy
+  at all.
 
   `--set` does not touch `CHANGELOG.md`. That entry needs release notes a script
   cannot write, so the check reports it as missing until you write it.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **A local-first command-line tool for operating Reolink cameras — JSON by default, with a built-in MCP server and a cross-agent skill so AI agents drive the same core.**
 
-![version](https://img.shields.io/badge/version-0.10.5-blue)
+![release](https://img.shields.io/github/v/release/reolink/reolink-cli)
 ![platform](https://img.shields.io/badge/platform-macOS%20·%20Linux%20·%20Windows-lightgrey)
 ![build](https://img.shields.io/badge/build-external%20·%20LAN--only-green)
 

--- a/scripts/check-version-sync.sh
+++ b/scripts/check-version-sync.sh
@@ -3,12 +3,14 @@
 #
 #   ./scripts/check-version-sync.sh              # compare against the latest release
 #   ./scripts/check-version-sync.sh 0.10.1       # compare against a version you name
-#   ./scripts/check-version-sync.sh --self       # only: do the nine agree with each other?
+#   ./scripts/check-version-sync.sh --self       # only: do the manifests agree with each other?
 #   ./scripts/check-version-sync.sh --set 0.11.0 # rewrite all of them, then check
 #
 # Exits non-zero and lists every file that disagrees.
 #
-# Why this exists: the version appears in nine places, and keeping them in step
+# Why this exists: the version appears in seven manifests (it was nine — the
+# README badge is a live shields.io lookup now, and the skill's example output
+# no longer names a version), and keeping them in step
 # by hand has failed three times — once leaving the plugin manifests behind, once
 # leaving this entire repository on the previous version while the release was
 # already published, and once more while cutting 0.10.3. Readers saw a 0.10.0
@@ -43,10 +45,13 @@ for arg in "$@"; do
   esac
 done
 
-# --self asks only "do these nine agree with each other?", taking package.json as
-# the reference. It exists for pull requests: a branch may legitimately carry a
-# version no release uses yet, but a hand-edit that updates eight of nine files
-# is never legitimate. Comparing against the published release is the separate
+# --self asks only "do these manifests agree with each other?", taking
+# package.json as the reference. It exists for pull requests: a branch may
+# legitimately carry a version no release uses yet, but a hand-edit that misses
+# one of the manifests is never legitimate. Note that the checksums-file check
+# below applies here too — a version bump and its checksums/<tag>.sha256 must
+# travel in the same pull request, because the installers fail closed on a
+# missing file the moment the bump reaches the default branch. Comparing against the published release is the separate
 # check, and it belongs on `release: published` and a schedule.
 if [ "$self" -eq 1 ]; then
   [ -z "$want" ] || { echo "--self takes no version argument" >&2; exit 2; }
@@ -64,7 +69,7 @@ if [ "$mode" = set ]; then
 fi
 
 # Exactly three numeric segments. A looser test accepts a typo like "0.10.3.1"
-# and --set would then stamp it into all nine files without complaint.
+# and --set would then stamp it into every manifest without complaint.
 if [ -n "$want" ]; then
   _rest=${want#*.}
   # Two dots exactly. Without this, "1.2" parses as major=1 minor=2 patch=2 —
@@ -90,11 +95,9 @@ fi
 # check and the rewrite pick it up — two lists that must agree is the same class
 # of bug this script exists to catch.
 #
-# Kinds: json   — a manifest with a "version" field (marketplace.json nests it
-#                 inside a plugin entry, so take the first match rather than
-#                 assuming a fixed depth)
-#        badge  — the README shields.io version badge
-#        setup  — the `--version` example output in the skill's setup notes
+# Kind: json — a manifest with a "version" field (marketplace.json nests it
+#              inside a plugin entry, so take the first match rather than
+#              assuming a fixed depth)
 LOCATIONS='
 package.json:json
 openclaw.plugin.json:json
@@ -103,15 +106,11 @@ gemini-extension.json:json
 .claude-plugin/marketplace.json:json
 .codex-plugin/plugin.json:json
 .cursor-plugin/plugin.json:json
-README.md:badge
-skills/reolink-cli/references/setup.md:setup
 '
 
 extract() { # file kind
   case "$2" in
     json)  sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([0-9][^"]*\)".*/\1/p' "$1" | head -n1 ;;
-    badge) sed -n 's/.*version-\([0-9][0-9.]*\)-blue.*/\1/p'                      "$1" | head -n1 ;;
-    setup) sed -n 's/.*reolink-cli --version.*# *→ *\([0-9][0-9.]*\).*/\1/p'      "$1" | head -n1 ;;
   esac
 }
 
@@ -120,8 +119,6 @@ extract() { # file kind
 rewrite() { # file kind version
   case "$2" in
     json)  sed "1,/\"version\"/s/\"version\"\([[:space:]]*\):\([[:space:]]*\)\"[0-9][^\"]*\"/\"version\"\1:\2\"$3\"/" "$1" > "$1.tmp" ;;
-    badge) sed "1,/version-[0-9]/s/version-[0-9][0-9.]*-blue/version-$3-blue/"                                        "$1" > "$1.tmp" ;;
-    setup) sed "1,/reolink-cli --version/s/\(reolink-cli --version.*# *→ *\)[0-9][0-9.]*/\1$3/"                        "$1" > "$1.tmp" ;;
   esac
   mv "$1.tmp" "$1"
 }

--- a/skills/reolink-cli/references/setup.md
+++ b/skills/reolink-cli/references/setup.md
@@ -27,7 +27,7 @@ tar -xzf "$tmp"/*.tar.gz -C "$tmp"
 cp "$tmp"/*/bin/reolink-cli "$tmp"/*/bin/reolink-gateway "$BIN/"
 chmod +x "$BIN/reolink-cli" "$BIN/reolink-gateway"; rm -rf "$tmp"
 case ":$PATH:" in *":$BIN:"*) ;; *) echo "NOTE: add $BIN to your PATH";; esac
-reolink-cli --version   # → 0.10.5 (external · LAN-only)
+reolink-cli --version   # → <version> (external · LAN-only)
 ```
 
 Windows: download the `...-windows-x86_64.zip` from the Releases page and put


### PR DESCRIPTION
Follow-up to #7, attacking the other half of the problem. The tooling (`--set`, `--self`, CI) manages the copies; this PR reduces how many copies exist. A copy that cannot go stale beats a copy that is checked.

## What changes

- **README version badge → live shields.io release lookup** (`img.shields.io/github/v/release/reolink/reolink-cli`). It now always shows the latest published release, with zero maintenance. The stale-badge-over-newer-download failure that #7 documented twice becomes structurally impossible for the badge.
- **The skill's setup notes no longer name a version.** The example output reads `# → <version> (external · LAN-only)` — the line was demonstrating the flavour suffix, not the number.
- **`check-version-sync.sh` shrinks from nine locations to seven** — the seven JSON manifests, which are irreducible: plugin systems (Claude marketplace, Codex, Cursor, Gemini, openclaw, npm-style tooling) read them from the repository in place, so they must carry real numbers.
- CONTRIBUTING and script comments updated to match, keeping the history of why.

## One behaviour worth calling out

`--self` (the PR check) now effectively enforces that **a version bump and its `checksums/<tag>.sha256` travel in the same pull request** — the existence check fails otherwise. That is deliberate, not incidental: since #35 the installers fail closed on a missing checksum file, so a bump reaching `main` without its file breaks `curl | sh` for every user at that instant. The CI failure on the PR is the fence before that cliff.

## Internal counterpart (context)

The same consolidation landed upstream where the binaries are built: the six crate versions collapsed into one `[workspace.package]` inheritance, and the packaging script reads the workspace root (the member files now say `version.workspace = true`, which the old extraction would have read literally). A release bump internally is now one line plus a human-written CHANGELOG entry.

## Tested

- `sh -n` passes; the check passes against published 0.10.5; `--self` passes.
- On a scratch copy: `--set 0.11.0` rewrites exactly the seven manifests (verified by count and by re-grep), and `--self` then fails on the missing `checksums/v0.11.0.sha256` — the new fence, firing where it should.
- The dynamic badge URL was fetched and renders the current release.
