### PR TITLE
docs: make the archive example platform-agnostic and zsh-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Grab the archive for your platform from the
 extract, and run the bundled installer:
 
 ```bash
-tar -xzf reolink-cli-*-external-darwin-arm64.tar.gz && cd reolink-cli-* && ./install.sh
+tar -xzf reolink-cli-*.tar.gz && cd reolink-cli-*/ && ./install.sh
 # Windows: extract the .zip and run .\install.ps1
 ```
 


### PR DESCRIPTION
## What changes

Fixes #39. The "Prefer a downloadable archive?" example hardcoded the darwin-arm64 filename in the `tar` command — a Linux user (two of the four supported platforms) pasting it got `Cannot open: No such file or directory`. Separately, the `cd reolink-cli-*` half failed in zsh, macOS's default shell: after extraction the glob matches both the extracted directory and the tarball, and zsh's two-argument `cd` does string substitution (`string not in pwd`). The line now uses a platform-agnostic tar glob (the user only has the one archive they downloaded) and a trailing slash so the `cd` glob matches directories only:

```bash
tar -xzf reolink-cli-*.tar.gz && cd reolink-cli-*/ && ./install.sh
```

## How it was verified

Ran both the old and new lines against the real v0.10.4 darwin-arm64 archive. Old line: `cd` fails in zsh with `string not in pwd` (works in bash only because bash ignores `cd`'s extra arguments). New line: extraction, `cd`, and `install.sh` lookup all succeed in **both bash and zsh**, end to end.

## Checklist

- [x] No password, camera UID, or private network address appears in the diff
- [x] Docs updated if a flag, output field, or default changed
- [ ] `cargo test --workspace` passes — N/A: this repo contains no Rust source; README only
