### PR TITLE
docs: stop telling Windows users to self-update in the quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ curl -fsSL https://raw.githubusercontent.com/reolink/reolink-cli/main/install.sh
 iwr https://raw.githubusercontent.com/reolink/reolink-cli/main/install.ps1 | iex
 ```
 
-Already installed? Upgrade in place with `reolink-cli self-update --yes`.
+Already installed? On macOS/Linux, upgrade in place with
+`reolink-cli self-update --yes`. On Windows, re-run the installer
+(`install.ps1`) — see [Platform support](#platform-support) for why.
 
 <details>
 <summary>Prefer a downloadable archive?</summary>


### PR DESCRIPTION
## What changes

Fixes #41. The first upgrade instruction in the README was unconditional — "Upgrade in place with `reolink-cli self-update --yes`" — but `self-update` covers macOS and Linux only; on Windows it exits with a download link (the archive is a `.zip` and a running `.exe` cannot be replaced in place), which the README itself only explains 134 lines later under Platform support. The quick-start line now qualifies the platforms and points Windows at re-running `install.ps1`, linking to [Platform support](#platform-support) for the reason.

## How it was verified

Cross-checked the two README statements against each other and against the v0.10.1 release notes, which describe the Windows exit-with-link behavior as intentional (`self-update` only untars, and a running `.exe` cannot be replaced in place). The `#platform-support` anchor was checked against the actual `## Platform support` heading. Docs-only; no command behavior involved.

## Checklist

- [x] No password, camera UID, or private network address appears in the diff
- [x] Docs updated if a flag, output field, or default changed
- [ ] `cargo test --workspace` passes — N/A: this repo contains no Rust source; README only
