### PR TITLE
fix: skill setup snippet could never download the binary

### DIFF
--- a/skills/reolink-cli/references/setup.md
+++ b/skills/reolink-cli/references/setup.md
@@ -11,10 +11,10 @@ set -e
 REPO="reolink/reolink-cli"
 BIN="$HOME/.local/bin"; mkdir -p "$BIN"
 os=$(uname -s); arch=$(uname -m)
-case "$os" in Darwin) os=macos;; Linux) os=linux;; esac
+case "$os" in Darwin) os=darwin;; Linux) os=linux;; esac
 case "$arch" in aarch64) arch=arm64;; x86_64|amd64) arch=x86_64;; esac
-[ "$os" = macos ] && [ "$arch" = x86_64 ] && { echo "macOS Intel not supported — Apple Silicon (arm64) only"; exit 1; }
-asset="reolink-cli-*-${os}-${arch}.tar.gz"
+[ "$os" = darwin ] && [ "$arch" = x86_64 ] && { echo "macOS Intel not supported — Apple Silicon (arm64) only"; exit 1; }
+asset="reolink-cli-*-external-${os}-${arch}.tar.gz"
 tmp=$(mktemp -d)
 if command -v gh >/dev/null 2>&1; then
   gh release download --repo "$REPO" --pattern "$asset" --dir "$tmp"


### PR DESCRIPTION
## What changes

Fixes #43. The skill's manual-install snippet could never download a binary: `Darwin) os=macos` while the published assets use `darwin`, and the asset pattern lacked the `external` flavour segment, so the curl fallback's sed substitution built `reolink-cli-<ver>-macos-arm64.tar.gz` — a filename that has never existed on any release. Same naming drift the 0.10.1 release fixed in `self-update`; the snippet kept the old tokens. Now `os=darwin` (and the matching Intel guard) with `reolink-cli-*-external-${os}-${arch}.tar.gz`.

## How it was verified

Ran both fixed paths against the live v0.10.5 release: `gh release download --pattern 'reolink-cli-*-external-darwin-arm64.tar.gz'` fetches the asset, and the curl-fallback filename the snippet constructs (`reolink-cli-0.10.5-external-darwin-arm64.tar.gz`) is a byte-for-byte match with an existing release asset name.

One observation left in the issue rather than this PR: the snippet installs the binaries without checksum verification, which could now use the `checksums/<tag>.sha256` model from #35 — that extends a trust-model decision, so it's flagged for a maintainer call instead of changed here.

## Checklist

- [x] No password, camera UID, or private network address appears in the diff
- [x] Docs updated if a flag, output field, or default changed
- [ ] `cargo test --workspace` passes — N/A: this repo contains no Rust source; skill doc only
