### PR TITLE
fix: week-table bitmap was documented backwards

### DIFF
--- a/skills/reolink-cli/references/recording.md
+++ b/skills/reolink-cli/references/recording.md
@@ -29,9 +29,9 @@ reolink-cli --camera front-door --gateway-addr 127.0.0.1:9000 record config get
 
 ## Rules
 
-- `--week-table` is a **7-bit bitmap, Mon=bit0 … Sun=bit6**. Common values:
-  - Weekdays (Mon–Fri): `31`
-  - Mon–Sat: `63`
+- `--week-table` is a **7-bit bitmap, Sun=bit0 … Sat=bit6** (matches `--help`). Common values:
+  - Weekdays (Mon–Fri): `62`
+  - Mon–Sat: `126`
   - All week: `127`
 - **Must** read current (`record schedule get`) before overwriting — SET replaces the full schedule object.
 - **Must** warn before `record schedule set --disable` — no new recordings will be written until re-enabled.
@@ -53,7 +53,7 @@ reolink-cli --camera front-door record schedule set --disable
 ## Weekly window (Mon–Sat 08:00–22:00)
 
 ```bash
-reolink-cli --camera front-door record schedule set --enable --plan-type weekly --week-table 63 \
+reolink-cli --camera front-door record schedule set --enable --plan-type weekly --week-table 126 \
   --start-hour 8 --start-min 0 --end-hour 22 --end-min 0
 ```
 


### PR DESCRIPTION
## What changes

Fixes #44. `recording.md` documented `--week-table` as "Mon=bit0 … Sun=bit6" with weekdays=`31` and Mon–Sat=`63`; the binary's help says `bit0=Sun .. bit6=Sat`, so those values schedule the wrong days — `31` is Sun–Thu, and the file's own "Weekly window (Mon–Sat)" example passed `63`, which is Sun–Fri: recording silently happens on Sunday and is missing on Saturday, with no error anywhere. Corrected to the binary's bit order with weekdays=`62`, Mon–Sat=`126` (all-week `127` was already right), example updated to `126`.

## How it was verified

Bit order taken from the v0.10.5 binary's `record schedule set --help` ("Weekly day bitmap (bit0=Sun .. bit6=Sat)"); values re-derived from that order. Stated plainly: no camera write was performed to verify device-side behaviour — the fix trusts the binary's own help over the doc's contradicting claim.

## Checklist

- [x] No password, camera UID, or private network address appears in the diff
- [x] Docs updated if a flag, output field, or default changed
- [ ] `cargo test --workspace` passes — N/A: this repo contains no Rust source; skill doc only
