### PR TITLE
fix: motion sensitivity is 1-50, not 0-100

### DIFF
--- a/skills/reolink-cli/references/detection.md
+++ b/skills/reolink-cli/references/detection.md
@@ -9,13 +9,15 @@ Motion (`detect motion`) and per-type AI (`detect ai`). AI types: `person | vehi
 - **Must** run `device inventory --capabilities` before scripting `detect ai --type X` across multiple devices — AI-type support varies per model (battery cams may only support `person`).
 - **Must** warn the user before `detect motion|ai set --disable` — disabling stops push notifications, white-LED alarm trigger, and md-rule recording downstream.
 - **Forbidden** asserting a device supports a specific AI type without capability confirmation.
-- `--sensitivity` is 0–100 (100 = most sensitive). Low values (≤ 20) will miss small/distant motion.
+- `--sensitivity` scales differ per command (higher = more sensitive on both):
+  `detect motion set` takes **1–50** (v20 MD spec range, default 9);
+  `detect ai set` takes **0–100**. Values valid for one are out of range for the other.
 
 ## Motion
 
 ```bash
 reolink-cli --camera front-door detect motion get
-reolink-cli --camera front-door detect motion set --enable --sensitivity 60
+reolink-cli --camera front-door detect motion set --enable --sensitivity 30
 reolink-cli --camera front-door detect motion set --disable --use-pir
 ```
 


### PR DESCRIPTION
## What changes

Fixes #45. `detection.md` stated a single sensitivity scale — 0–100 — for both detect commands. The v0.10.5 binary has two: `detect motion set` takes **1–50** (v20 MD spec range, default 9) and `detect ai set` takes **0–100**. The blanket rule sent motion values out of range, and the file's own motion example passed `--sensitivity 60`. The rule now states both scales, and the motion example uses `30`; the AI examples (80/70/50) were already valid.

## How it was verified

Both ranges taken directly from the v0.10.5 binary's `--help` output for the two subcommands (`detect motion set` and `detect ai set`). Docs-only change.

## Checklist

- [x] No password, camera UID, or private network address appears in the diff
- [x] Docs updated if a flag, output field, or default changed
- [ ] `cargo test --workspace` passes — N/A: this repo contains no Rust source; skill doc only
