### PR TITLE
docs: three small drifts — deprecated flag example, missing endpoint, stale count

### DIFF
--- a/.github/workflows/version-sync.yml
+++ b/.github/workflows/version-sync.yml
@@ -1,4 +1,4 @@
-# The version appears in nine places in this repository plus a CHANGELOG
+# The version appears in seven places in this repository plus a CHANGELOG
 # heading, and keeping them in step by hand has failed three times — once
 # leaving the plugin manifests behind, once leaving the whole repository a
 # version back while the release was already published (readers saw a 0.10.0
@@ -10,7 +10,7 @@
 #
 # Two different questions, so two different triggers:
 #
-#   --self   do the nine agree with each other?  → every PR and push.
+#   --self   do the seven agree with each other?  → every PR and push.
 #            A branch may legitimately carry a version no release uses yet, so
 #            this deliberately does not look at the published release.
 #

--- a/skills/reolink-cli/references/controls.md
+++ b/skills/reolink-cli/references/controls.md
@@ -13,8 +13,9 @@ reolink-cli --camera front-door light ir set --state auto    # or on / off
 reolink-cli --camera front-door light statusled get
 reolink-cli --camera front-door light statusled set --state off
 
-# Spotlight (manual, 0 = until turned off)
-reolink-cli --camera front-door light spotlight set --enable --duration 30
+# Spotlight (manual; --duration is deprecated — re-arming extends the
+# on-period, it does not pulse; use `light spotlight blink` for flashes)
+reolink-cli --camera front-door light spotlight set --enable
 reolink-cli --camera front-door light spotlight set --disable
 
 # White LED alarm config

--- a/skills/reolink-cli/references/gateway-http.md
+++ b/skills/reolink-cli/references/gateway-http.md
@@ -65,6 +65,9 @@ curl -s -o /tmp/snap.jpg "http://127.0.0.1:9000/api/snapshot?token=$TOKEN&host=1
 curl -s -o /tmp/clip.h264 "http://127.0.0.1:9000/api/vod/download?token=$TOKEN&host=192.168.1.43:9000&fileName=$NAME"
 ```
 
+There is a fourth streaming endpoint, `/api/preview/video` (live video for
+browser `<video src>` elements), with the same token-in-query rule.
+
 ## Response Shapes
 
 ```jsonc


### PR DESCRIPTION
## What changes

Fixes #46. Three small drifts, one commit:

- **controls.md** — the spotlight example used `--duration 30`, which the v0.10.5 binary marks deprecated in its own help ("re-arming extends the on-period, it does not pulse — use `light spotlight blink`"). The example now omits it and carries the same warning.
- **gateway-http.md** — SKILL.md lists four streaming endpoints and calls this file "the full spec", but it documented three. `/api/preview/video` is now named with the same token-in-query rule. Only what's verifiable is stated — its further query parameters are documented nowhere in the repo, so no example URL is invented.
- **.github/workflows/version-sync.yml** — header comments still said "nine places" / "do the nine agree" after #37 cut the list to seven (the script's own header already says seven). Comment-only; no workflow logic touched.

## How it was verified

Deprecation text and endpoint list cross-checked against the v0.10.5 binary's `light spotlight set --help` and SKILL.md line 263; the workflow change is comments only, and `--self` still passes locally (`./scripts/check-version-sync.sh --self`).

## Checklist

- [x] No password, camera UID, or private network address appears in the diff
- [x] Docs updated if a flag, output field, or default changed
- [ ] `cargo test --workspace` passes — N/A: this repo contains no Rust source; docs + workflow comments only
