### PR TITLE
docs: cite the source for values; check documented commands mechanically

### DIFF
--- a/scripts/check-doc-commands.py
+++ b/scripts/check-doc-commands.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Run every `reolink-cli …` command that appears in the docs through the real
+binary's argument parser, and report the ones it rejects.
+
+    ./scripts/check-doc-commands.py [--cli path/to/reolink-cli] [docs-root ...]
+
+Why this exists: the reference docs assert what the CLI accepts, and nothing
+verified those assertions. An outside contributor read them against the binary
+and filed six defects in one day — one of which (`detect motion set
+--sensitivity 60`, valid range 1–50) this script now catches on its own. Code
+has a compiler and a test suite; prose had neither.
+
+What it can and cannot see. clap validates subcommands, flag names, and value
+ranges during parsing, before any command runs — so those are checkable, and
+this script checks them. It cannot see whether a documented *meaning* is right:
+a bit order, a deprecation note, a claim about Windows. Those need a reader.
+Reducing that second class is a docs-design job (point at `--help` instead of
+restating it), not something a checker can do.
+
+Safety: commands run against TEST-NET-1 (192.0.2.0/24, unroutable by RFC 5737)
+with the gateway pointed at a closed port and config/registry paths redirected
+into a temp dir, so a command that parses cleanly fails at the first connection
+attempt without touching a device or the real config.
+"""
+import argparse
+import os
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Values a doc writes for the reader to substitute. A parse error caused by one
+# of these is the doc working as intended, not a defect.
+PLACEHOLDER = re.compile(r"[<>${}\[\]]|^[A-Z][A-Z0-9_-]*$|\.\.\.|…|^[~/]")
+
+# PowerShell wrappers (`Start-Process reolink-cli -ArgumentList "…"`). A
+# -CapitalWord parameter is PowerShell convention and never a Unix CLI flag, so
+# it is a reliable marker that this line is not a shell command to parse.
+POWERSHELL = re.compile(r"^-[A-Z]")
+
+# Shell that lives on the same line as the command and is not part of it,
+# plus the prose a doc puts after a command to explain it — a trailing
+# "(recent fires)" is an annotation, not an argument.
+TRAILING_SHELL = re.compile(r"\s+(?:#|&&|\|\||[&;|>]|\().*$")
+
+FAILURE = re.compile(
+    r"error: (invalid value '[^']*' for '[^']*'[^\n]*"
+    r"|unexpected argument [^\n]*"
+    r"|unrecognized subcommand [^\n]*"
+    r"|the following required arguments[^\n]*)"
+)
+
+
+def commands_in(path: Path):
+    """Yield commands from fenced code blocks only.
+
+    Prose mentions a command the way it mentions anything else — inside a
+    sentence, sometimes with the surrounding words attached ("Remove
+    reolink-cli + reolink-gateway"). Only a fenced block is a claim that this
+    exact line runs, so only a fenced block is worth checking. Scanning prose
+    produced four findings, all of them the checker misreading English.
+    """
+    fenced = False
+    for lineno, line in enumerate(path.read_text(errors="ignore").splitlines(), 1):
+        if line.lstrip().startswith("```"):
+            fenced = not fenced
+            continue
+        if not fenced:
+            continue
+        for m in re.finditer(r"\breolink-cli\s+([^\n|`]*)", line):
+            raw = TRAILING_SHELL.sub("", m.group(1)).strip().rstrip("\\").strip()
+            if raw and not raw.startswith("#"):
+                yield lineno, raw
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cli", default="reolink-cli")
+    ap.add_argument("roots", nargs="*", default=["."])
+    args = ap.parse_args()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        env = dict(
+            os.environ,
+            REOLINK_CAMERAS_FILE=f"{tmp}/aliases.toml",
+            REOLINK_CONFIG_FILE=f"{tmp}/config.toml",
+            REOLINK_GATEWAY_ADDR="127.0.0.1:1",
+            REOLINK_PASSWORD="placeholder",
+        )
+        checked = skipped = 0
+        findings = []
+        for root in args.roots:
+            for md in sorted(Path(root).rglob("*.md")):
+                if "node_modules" in md.parts:
+                    continue
+                for lineno, cmd in commands_in(md):
+                    try:
+                        toks = shlex.split(cmd)
+                    except ValueError:
+                        skipped += 1
+                        continue
+                    if not toks or any(
+                        PLACEHOLDER.search(t) or POWERSHELL.match(t) for t in toks
+                    ):
+                        skipped += 1
+                        continue
+                    checked += 1
+                    try:
+                        r = subprocess.run(
+                            [args.cli, *toks],
+                            capture_output=True,
+                            text=True,
+                            timeout=20,
+                            env=env,
+                        )
+                    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+                        if isinstance(e, FileNotFoundError):
+                            print(f"cannot run {args.cli!r}", file=sys.stderr)
+                            return 2
+                        continue
+                    hit = FAILURE.search((r.stderr or "") + (r.stdout or ""))
+                    if hit:
+                        findings.append((md, lineno, cmd, hit.group(1)))
+
+    print(f"checked {checked} documented commands ({skipped} skipped as placeholders)")
+    if not findings:
+        print("all of them parse.")
+        return 0
+    print()
+    for md, lineno, cmd, err in findings:
+        print(f"  {md}:{lineno}")
+        print(f"      {cmd}")
+        print(f"      -> {err}")
+    print(f"\n{len(findings)} documented command(s) the CLI rejects.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/reolink-cli/references/controls.md
+++ b/skills/reolink-cli/references/controls.md
@@ -13,7 +13,8 @@ reolink-cli --camera front-door light ir set --state auto    # or on / off
 reolink-cli --camera front-door light statusled get
 reolink-cli --camera front-door light statusled set --state off
 
-# Spotlight (manual, 0 = until turned off)
+# Spotlight (manual on/off; see `light spotlight set --help` for --duration's
+# status, and `light spotlight blink` for repeated flashes)
 reolink-cli --camera front-door light spotlight set --enable --duration 30
 reolink-cli --camera front-door light spotlight set --disable
 

--- a/skills/reolink-cli/references/detection.md
+++ b/skills/reolink-cli/references/detection.md
@@ -9,9 +9,11 @@ Motion (`detect motion`) and per-type AI (`detect ai`). AI types: `person | vehi
 - **Must** run `device inventory --capabilities` before scripting `detect ai --type X` across multiple devices — AI-type support varies per model (battery cams may only support `person`).
 - **Must** warn the user before `detect motion|ai set --disable` — disabling stops push notifications, white-LED alarm trigger, and md-rule recording downstream.
 - **Forbidden** asserting a device supports a specific AI type without capability confirmation.
-- `--sensitivity` scales differ per command (higher = more sensitive on both):
-  `detect motion set` takes **1–50** (v20 MD spec range, default 9);
-  `detect ai set` takes **0–100**. Values valid for one are out of range for the other.
+- `--sensitivity` uses **different scales for motion and AI** (higher = more
+  sensitive on both), so a value valid for one is rejected by the other. Read the
+  accepted range from `--help` rather than assuming — it is enforced at parse
+  time, so a wrong value fails before touching the camera:
+  `reolink-cli detect motion set --help`, `reolink-cli detect ai set --help`.
 
 ## Motion
 

--- a/skills/reolink-cli/references/recording.md
+++ b/skills/reolink-cli/references/recording.md
@@ -29,7 +29,11 @@ reolink-cli --camera front-door --gateway-addr 127.0.0.1:9000 record config get
 
 ## Rules
 
-- `--week-table` is a **7-bit bitmap, Sun=bit0 … Sat=bit6** (matches `--help`). Common values:
+- `--week-table` is a **7-bit bitmap, Sun=bit0 … Sat=bit6** — verified against
+  the vendor SDK (`BCNetSDK.h`: `iWeekTable` → *"index 0:sunday, index 1~index
+  6:Monday->Saturday"*, and `weekdays_bitmap` → *"bit0 sunday"*). This document
+  carried Mon=bit0 until 2026-07-31, so any value copied from it before then
+  selects the wrong days. Common values:
   - Weekdays (Mon–Fri): `62`
   - Mon–Sat: `126`
   - All week: `127`


### PR DESCRIPTION
Follow-up to #47 through #50. Those six PRs were all the same defect wearing different clothes: a fact that lives in the code, restated in prose, where the restatement drifted and nothing noticed. `--help` said 1–50 and the doc said 0–100; `--help` said DEPRECATED and the doc recommended the flag; `install.sh` said `darwin` and the skill snippet said `macos`. This PR goes after the two halves of that.

## Cite the source, or stop restating it

**`--week-table` now names its authority** rather than pointing at `--help`. #48 was right, and I can now say *why* rather than "because it matches the help text": the vendor SDK defines the field in the weekly-plan struct itself —

```c
/**
 * @param iWeekTable
 * index 0:sunday
 * index 1~index 6:Monday->Saturday
 */
int iWeekTable[7];
```

— with four corroborating definitions in the same header (`weekdays_bitmap // bit0 sunday`, `iStartWeekday // 0: sunday`, `iWeek[7] // 0=Sunday ... 6=Saturday`, and the `E_BC_RA_EVERY_SUNDAY, E_BC_RA_EVERY_MONDAY` enum order). The note also records that the doc carried Mon=bit0 until today, because a value copied from it before then selects the wrong days and nothing about the resulting schedule looks broken.

**`--sensitivity` and spotlight `--duration` go the other way**: the doc no longer restates the accepted range or the deprecation status, it points at `--help`, which is generated from the code and cannot drift. What stays is the part `--help` cannot say — that motion and AI use *different* scales, which is the trap, not the numbers.

The rule this follows: state a fact in prose only when prose is the only place it can live. Otherwise cite where it lives.

## Check the documented commands mechanically

`scripts/check-doc-commands.py` extracts every `reolink-cli …` line from fenced code blocks and feeds it to the real binary's parser. clap validates subcommands, flag names, and value ranges during parsing, before a command does anything — so those three layers are checkable, and this checks them.

```
$ ./scripts/check-doc-commands.py --cli reolink-cli
checked 169 documented commands (31 skipped as placeholders)
all of them parse.
```

Safety: commands run against TEST-NET-1 (192.0.2.0/24, unroutable per RFC 5737) with the gateway pointed at a closed port and config paths redirected to a temp dir, so anything that parses cleanly dies at the first connection attempt without touching a device or the real config.

Verified it catches rather than just passes: restoring `--sensitivity 60` (the #49 defect) makes it report

```
invalid value '60' for '--sensitivity <SENSITIVITY>': 60 is not in 1..=50
```

Getting to a clean run took three rounds of fixing the checker, not the docs — it first reported 121 findings because it compared subcommand flags against the root help, then 31 because it read trailing prose (`(recent fires)`) as arguments. Both were the checker misreading, and the current version only scans fenced blocks and skips PowerShell wrappers for that reason.

**What it cannot see**, stated plainly because the gap matters: whether a documented *meaning* is correct. A bit order, a deprecation note, a claim about Windows — all parse fine and can all be wrong. That class is what a human reader catches, and reducing it is the job of the first half of this PR, not the second.
