### PR TITLE
release: 0.10.6

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "reolink-cli",
       "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "source": "./",
       "author": {
         "name": "Reolink"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "author": {
     "name": "reolink"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Plugin for operating Reolink cameras through the local CLI.",
   "author": {
     "name": "Reolink"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "reolink-cli",
   "displayName": "Reolink CLI",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "author": {
     "name": "Reolink"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,87 @@ All notable changes to the public `reolink-cli` distribution are documented here
 This is the customer-facing release history; it tracks the LAN-only (external)
 builds published as GitHub Releases.
 
+## [0.10.6] — 2026-07-31
+
+Most of this release came from issues and pull requests opened here.
+
+### Fixed
+
+- **`discover` dropped the UID and device name for any device that answered
+  both probes** (#36). Deduplication kept the ONVIF record and discarded the
+  Reolink broadcast record wholesale, under a code comment praising ONVIF's
+  "rich metadata" — but the UID and the friendly name live *only* in the
+  broadcast reply, and those are the two fields that let a person tell eleven
+  cameras apart. The reporter had four devices listing without UIDs on Linux.
+
+  Records are now merged per IP: the ONVIF entry gains the UID, the
+  `reolink-lan://name/…` scope, the device kind, and the port-qualified host
+  (`<ip>:9000`, which is what `device add --host` wants; a bare `<ip>` is not).
+  An existing UID is never overwritten.
+
+  Whether a device lands in `lan` or `lanUdp` depends on whether ONVIF is
+  enabled on it (off by default on many models) and whether the network passes
+  WS-Discovery (Windows Defender commonly eats it). The `counts` split still
+  differs between machines and now **stops mattering** — every entry carries the
+  same fields whichever bucket it landed in.
+
+  Verified by A/B against hardware: with ONVIF temporarily enabled on a camera
+  so it answered both probes, 0.10.5 reported `uid: null`, no name and a bare-IP
+  host; this build reports all three with the ONVIF metadata intact.
+
+### Documentation
+
+Six pull requests from @ch-bas, all of them the same defect wearing different
+clothes: a fact that lives in the code, restated in prose, where the
+restatement had drifted.
+
+- **`--week-table` was documented backwards** (#48). It is `Sun=bit0 … Sat=bit6`,
+  now stated with its authority: the vendor SDK defines `iWeekTable` as *"index
+  0:sunday, index 1~index 6:Monday->Saturday"*, with four corroborating
+  definitions in the same header. The doc said `Mon=bit0` until today, so the
+  `31` and `63` copied from it select the wrong days — and a schedule on the
+  wrong days does not look broken.
+- **`detect motion set --sensitivity` is 1–50, not 0–100** (#49). The range is
+  enforced by the parser, so the doc's own example (`--sensitivity 60`) could
+  never run. Confirmed three ways: the v20 spec, and both a camera and an NVR
+  reporting `{"min": 1, "max": 50}` for themselves.
+- **The skill's install snippet could never download anything on macOS** (#47):
+  it mapped `Darwin` to `macos` while the published asset says `darwin`, and its
+  glob omitted `-external-`.
+- **Windows users are no longer told to `self-update`** in the quick start
+  (#42) — it covers macOS and Linux only, as the same README says further down.
+- **The archive example is platform-agnostic and zsh-safe** (#40); zsh treats an
+  unmatched glob as an error rather than passing it through.
+- Reference docs no longer restate value ranges or deprecation status (#50).
+  `--help` is generated from the code and cannot drift; a hand-copy only gets
+  staler. What stays is what `--help` cannot say — for instance that motion and
+  AI sensitivity use *different* scales, which is the trap, not the numbers.
+
+### Build
+
+- The version lived in sixteen hand-edited places; now it lives in two. The six
+  crates inherit `[workspace.package]`, both README badges became live
+  shields.io release lookups (a copy that cannot go stale beats a copy that is
+  checked), and the skill's example output no longer names a version. Cutting a
+  release is now one line plus a CHANGELOG entry.
+- `scripts/check-doc-commands.py` feeds every `reolink-cli` line in a fenced
+  code block to the real binary's parser, which validates subcommands, flag
+  names and value ranges before a command does anything. It runs against
+  TEST-NET-1 with config paths redirected to a temp dir, so nothing touches a
+  device. Verified to catch rather than merely pass: restoring `--sensitivity
+  60` makes it fail. It cannot see whether a documented *meaning* is right —
+  that class is what a human reader catches.
+
+### Policy
+
+- **Published releases and tags are permanent from now on** (#38). Deleting a
+  superseded release breaks every downstream pinning that version, and it was
+  wrong of us to do it. `v*` tags are now protected by a ruleset with no bypass
+  actors (verified: an admin deletion attempt returns 422). Releases 0.10.0
+  through 0.10.4 were deleted under the old policy and cannot be honestly
+  restored; **0.10.5 is the oldest surviving release and the first one covered
+  by this guarantee.**
+
 ## [0.10.5] — 2026-07-30
 
 ### Fixed

--- a/checksums/v0.10.6.sha256
+++ b/checksums/v0.10.6.sha256
@@ -1,0 +1,4 @@
+8d1904b2a08a26d43ce14b7000a2403dc93a1c1db2f35b6c164e0169d8790694  reolink-cli-0.10.6-external-darwin-arm64.tar.gz
+6804451b81986536230892bd80426c173f854f862d49d5518e276ffce296192d  reolink-cli-0.10.6-external-linux-arm64.tar.gz
+c5bbb393adc81d4938279c254bbe1145c54eff7fcbe5a6ea3eb0e08a935f0974  reolink-cli-0.10.6-external-linux-x86_64.tar.gz
+12cb7778d52e7750365e42a6b752fe97285d8064157141143155edf2751b2327  reolink-cli-0.10.6-external-windows-x86_64.zip

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "contextFileName": "GEMINI.md"
 }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "reolink-cli",
   "name": "Reolink CLI",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "author": {
     "name": "Reolink"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "type": "module",
   "description": "Operate Reolink cameras locally via reolink-cli.",
   "main": ".opencode/plugins/reolink-cli.js",

--- a/skills/reolink-cli/references/controls.md
+++ b/skills/reolink-cli/references/controls.md
@@ -13,9 +13,9 @@ reolink-cli --camera front-door light ir set --state auto    # or on / off
 reolink-cli --camera front-door light statusled get
 reolink-cli --camera front-door light statusled set --state off
 
-# Spotlight (manual on/off; `--duration` is deprecated — see
-# `light spotlight set --help`. For repeated flashes: `light spotlight blink`)
-reolink-cli --camera front-door light spotlight set --enable
+# Spotlight (manual on/off; see `light spotlight set --help` for --duration's
+# status, and `light spotlight blink` for repeated flashes)
+reolink-cli --camera front-door light spotlight set --enable --duration 30
 reolink-cli --camera front-door light spotlight set --disable
 
 # White LED alarm config

--- a/skills/reolink-cli/references/gateway-http.md
+++ b/skills/reolink-cli/references/gateway-http.md
@@ -65,9 +65,6 @@ curl -s -o /tmp/snap.jpg "http://127.0.0.1:9000/api/snapshot?token=$TOKEN&host=1
 curl -s -o /tmp/clip.h264 "http://127.0.0.1:9000/api/vod/download?token=$TOKEN&host=192.168.1.43:9000&fileName=$NAME"
 ```
 
-There is a fourth streaming endpoint, `/api/preview/video` (live video for
-browser `<video src>` elements), with the same token-in-query rule.
-
 ## Response Shapes
 
 ```jsonc

--- a/skills/reolink-cli/references/setup.md
+++ b/skills/reolink-cli/references/setup.md
@@ -53,6 +53,25 @@ LAN discovery sends the native Reolink UDP probe on every active IPv4 interface
 broadcast domain plus `255.255.255.255`, so dual-NIC hosts should now see
 cameras on each directly attached subnet in one scan.
 
+**What each field means (and why two machines can bucket devices differently).**
+`discover` runs several probes in parallel and merges the answers per device:
+
+- The **Reolink UDP broadcast** (`lanUdp`) supplies the UID, the friendly name
+  (`reolink-lan://name/…` scope), the device kind, and the port-qualified host
+  (`<ip>:9000` — the form `device add --host` wants).
+- **ONVIF WS-Discovery** (`lan`) supplies the ONVIF endpoint, `xaddrs`, and the
+  hardware model in `onvif://…` scopes — **only for devices with ONVIF enabled**
+  in the camera/NVR settings (Network → Advanced → Port/server settings; it is
+  off by default on many models). Toggling ONVIF on a device adds or removes
+  this extra metadata in its entry; UID and name are unaffected.
+
+One device found by both probes yields ONE entry carrying the union of fields;
+the `discovery` label only records which probe answered. The `counts` split is
+therefore environmental, not meaningful: a firewall that eats WS-Discovery
+responses (common on Windows) moves devices from `lan` to `lanUdp` without
+changing what you learn about them. Do not treat `counts` differences across
+machines as a fault — compare the per-device fields instead.
+
 **When `discover` returns empty:**
 1. First run `reolink-cli device list` — user may already have cameras registered; if the target camera exists, verify with `ping` + `login` and report to the user. Don't invent data.
 2. If no matching camera is registered, ask the user whether they want to enter a known IP/UID manually (use `device add CAMERA --host IP:PORT --user admin`) or extend the timeout (`--timeout-secs 10`).
@@ -136,6 +155,7 @@ reolink-cli --camera front-door config get network
 reolink-cli --camera front-door config get osd
 reolink-cli --camera front-door config get osd-format
 reolink-cli --camera front-door config get system-general   # get-only
+reolink-cli --camera front-door config get performance      # get-only: live CPU / encoder / network load
 ```
 
 ```bash


### PR DESCRIPTION
Syncs the repository to 0.10.6 and lands `checksums/v0.10.6.sha256` **before** the release is published — the installers resolve the latest release and then look for its checksum file on `main`, so publishing first would fail-close every `curl | sh` until this merged.

Includes the six documentation fixes from @ch-bas (#40, #42, #47, #48, #49, #50) and the `discover` merge fix from #36.

`check-version-sync.sh` and `check-doc-commands.py` both pass.