### PR TITLE
docs: restore a reverted contribution, complete the endpoint list, check the mirror

### DIFF
--- a/scripts/check-docs-mirror.sh
+++ b/scripts/check-docs-mirror.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# The skill docs exist in two repositories and are mirrored by hand. This checks
+# they still agree.
+#
+#   ./scripts/check-docs-mirror.sh [path-to-public-clone]
+#
+# Why this exists: on 2026-07-31 a contributor's merged pull request was undone
+# within the hour. It had landed in the public repository; the release sync then
+# copied this repository's older copy over the top, and nothing noticed — not
+# review, not CI, not the person doing it. Two files, one fact, no mechanism.
+#
+# The real fix is one copy, not two. Until the mirror goes away, this at least
+# makes divergence loud, and it belongs in the release checklist BEFORE the
+# sync copy is made — that is the moment work gets destroyed.
+#
+# A difference is not automatically wrong: content for an unreleased change
+# legitimately sits here first. The point is that you look at it and decide,
+# rather than copying over the top and finding out later.
+set -eu
+
+here=$(cd "$(dirname "$0")/.." && pwd)
+public=${1:-$here/../reolink-cli-github}
+
+[ -d "$public/skills/reolink-cli" ] || {
+  echo "no public clone at $public — pass its path as the first argument" >&2
+  exit 2
+}
+
+mine="$here/plugins/reolink-cli/skills/reolink-cli"
+theirs="$public/skills/reolink-cli"
+
+status=0
+for f in $(cd "$mine" && find . -name '*.md' | sort); do
+  a="$mine/$f"
+  b="$theirs/$f"
+  name=${f#./}
+  if [ ! -f "$b" ]; then
+    printf '  ONLY HERE  %s\n' "$name"
+    status=1
+  elif ! diff -q "$a" "$b" >/dev/null 2>&1; then
+    # Direction matters: lines only in the public copy are the dangerous ones,
+    # because a sync copy from here would delete them.
+    lost=$(diff "$a" "$b" | grep -c '^>' || true)
+    added=$(diff "$a" "$b" | grep -c '^<' || true)
+    printf '  DIFFERS    %-46s here-only:%s  public-only:%s\n' "$name" "$added" "$lost"
+    [ "$lost" -gt 0 ] && printf '             ^ a sync copy from here would DELETE %s line(s) that exist only in public\n' "$lost"
+    status=1
+  fi
+done
+
+for f in $(cd "$theirs" && find . -name '*.md' | sort); do
+  [ -f "$mine/$f" ] || { printf '  ONLY PUBLIC %s\n' "${f#./}"; status=1; }
+done
+
+if [ "$status" -eq 0 ]; then
+  echo "  skill docs agree in both repositories."
+else
+  echo
+  echo "Review each difference before syncing. Content that landed in the public"
+  echo "repository (a merged pull request) must be brought back here first, or"
+  echo "the sync will silently revert it."
+fi
+exit $status

--- a/skills/reolink-cli/MAINTAINING.md
+++ b/skills/reolink-cli/MAINTAINING.md
@@ -1,0 +1,127 @@
+# Maintaining the `reolink-cli` Skill
+
+For future editors. Covers what the skill's invariants are, why the
+structure looks the way it does, and what to run when you change it.
+
+## Invariants (don't break these silently)
+
+1. **SKILL.md stays under ~250 lines.** It loads into context on every
+   skill invocation. Big tables (command reference signatures, intent
+   disambiguation, error recovery, side-effects, gotchas) are load-
+   bearing; verbose prose is not. If you're adding a table column or a
+   flag description that is only useful when the agent drills into a
+   specific command, put it in `references/<topic>.md` instead.
+2. **Every command mentioned in SKILL.md must exist in the CLI.** CI
+   enforces this via `scripts/check-skill-drift.sh`. A skill that
+   advertises a removed command is worse than a skill that stays quiet
+   about one (see the 5-stub-path incident that motivated the check).
+3. **Credential-safety rule is non-negotiable.** The "never pass
+   `--password PLAIN`" rule is cited by three places in the skill
+   (credential-safety numbered step, Users section caveat, intent table
+   entry). If you change wording in one, update the other two.
+4. **Intent disambiguation belongs in SKILL.md**, not in a reference
+   file. Benchmark eval-4 routinely finishes in 1 tool call precisely
+   because the intent table doesn't require opening a second file.
+5. **Gateway requirement must be stated up front.** Reason: without it,
+   a fresh agent hits `Connection refused` on every control command.
+   Don't move this to "Troubleshooting" — it's setup, not failure.
+
+## Why the structure looks like this
+
+- **199-line SKILL.md, 9 topic files under `references/`:** started from
+  a 321-line SKILL.md + 552-line monolithic `command-recipes.md`.
+  The monolith forced every task — even a simple `ptz move` — to drag
+  16k tokens of recipe into context. Topic-splitting cuts that to
+  ~1k tokens per task. Benchmark eval-2 load dropped from 2 files to 1.
+- **`references/index.md` is rarely read in practice.** The routing
+  table in SKILL.md itself is usually enough. index.md is a safety net
+  for agents that didn't load SKILL.md first; don't let it grow.
+- **`references/troubleshooting.md` holds both intent-map (full
+  verbose) AND decision trees.** Rationale: an agent that hits an
+  unfamiliar error *or* an ambiguous user phrasing both route to the
+  same file. Keep the two sections clearly separated with the same
+  H2-level headings.
+- **No `references/command-recipes.md` — it was removed.** If you're
+  tempted to add one back for cross-topic examples, first ask whether
+  the example actually spans topics. End-to-end examples live in
+  `docs/api-v30.md` (gateway HTTP) or `docs/cli-reference.md` (CLI).
+
+## What to run when you change something
+
+### Any skill edit
+
+```bash
+cargo build --bin reolink-cli
+./scripts/check-skill-drift.sh
+```
+
+This fails if SKILL.md references a command the CLI doesn't have.
+
+### Adding/removing a CLI command surface
+
+1. Update the CLI code + its `--help` text.
+2. Update `SKILL.md` Command Reference signature line.
+3. If the command has non-obvious flags or needs an example, add to
+   the matching `references/<topic>.md`.
+4. Update the intent table if a user might reach this command via a
+   loose phrasing ("the night lights", "what people does it see", …).
+5. Re-run `check-skill-drift.sh`.
+6. Consider adding a benchmark eval under
+   `plugins/reolink-cli/skills/reolink-cli-workspace/iteration-N/`
+   (see below).
+
+### Running the benchmark
+
+Pattern used in iter-5 … iter-7:
+
+1. Start gateway: `reolink-cli gateway start --addr 127.0.0.1:9000 &`
+2. For each eval:
+   - Dispatch a subagent with the eval's prompt verbatim + reference
+     paths to the skill + 5 assertions.
+   - Self-score (agent returns a JSON with pass-per-assertion).
+3. Aggregate into `iteration-N/benchmark.json` and `.md`. Reuse the
+   `without_skill` baseline from iter-4 (stable — underlying CLI
+   paths rarely change).
+4. Compare on: pass rate, mean time (seconds), mean tokens, average
+   files loaded from skill.
+
+Subagent cost per eval: ~25k tokens, ~30s wall-clock.
+
+### Adding a new eval
+
+Create `iteration-N/eval-M/eval_metadata.json`:
+
+```json
+{
+  "eval_id": M,
+  "eval_name": "kebab-case-name",
+  "prompt": "<the user request verbatim, Chinese or English>",
+  "assertions": [
+    {"text": "snake_case_id", "description": "What literally satisfies this in the run log"},
+    ... five total
+  ]
+}
+```
+
+Five assertions per eval (precedent). Keep them strictly mechanical —
+the self-scoring agent cannot evaluate intent, only "did this string
+appear / did this ordered pattern occur".
+
+## Red flags when editing
+
+- **Adding a long paragraph to SKILL.md** — ask whether it can be a
+  table row. If not, whether it belongs in a reference file.
+- **Duplicating content between SKILL.md and a reference** — pick one
+  canonical home and point to it from the other. Duplicates drift.
+- **"I'll just mention this command in prose"** — it won't be matched
+  by the drift check regex. Either use backtick syntax (`command …`)
+  or skip.
+- **Removing a gotcha because "agents should figure it out"** — every
+  entry in the Gotchas table was added because an agent literally
+  didn't figure it out. Leave them.
+
+## Contact
+
+Skill author sessions are stored under
+`.claude/projects/.../memory/` — check `project_v30_authority.md` and
+the reference-repo pointers for context on V20/V30 authority.

--- a/skills/reolink-cli/SKILL.md
+++ b/skills/reolink-cli/SKILL.md
@@ -39,7 +39,7 @@ Primary surface: `reolink-cli` (JSON stdout by default). Don't start the MCP ser
 reolink-cli gateway start --addr 127.0.0.1:9000 &
 ```
 
-Only `device add|list|update|remove|resolve|show`, `config init`, and `discover` work without it. Everything else (`ping`, `login`, `info`, `config get/set`, `image`, `osd`, `ptz`, `detect`, `light`, `audio`, `preview`, `snapshot`, `vod`, `events`, `users`, `system reboot`, `system upgrade`) needs the gateway up.
+Works **without** the gateway: `device add|list|update|remove|resolve|show`, `config init`, `discover`, `features`, `doctor`, `cache status|clean` — everything that reads local config or talks to the network directly. (Verified by running each with no gateway listening.) Everything else (`ping`, `login`, `info`, `config get/set`, `image`, `osd`, `ptz`, `detect`, `light`, `audio`, `preview`, `snapshot`, `vod`, `events`, `users`, `system reboot`, `system upgrade`) needs the gateway up.
 
 **Envelopes** — parse `.ok` on CLI, `.status` on gateway:
 
@@ -82,6 +82,7 @@ Resolve ambiguity before picking a command. If still unclear, **ask with options
 | kick off | `users remove` (permanent) OR `users passwd` + `system reboot` (evict session) | Active sessions survive `users remove` until reboot |
 | snapshot | `snapshot [--file PATH]` | JPEG. **Parent directories are auto-created** by the binary (since v0.5.0) — do NOT pre-`mkdir -p` the destination. Same for `vod download` and `preview capture --file`. |
 | **slow / how long / time taken / performance / latency / benchmark** | **`benchmark [--iterations N] [--phases ...] [--reuse-session]`** | Per-phase p50/p95/p99: connect, login, info, snapshot. `--reuse-session` for warm-path. Detail in `references/index.md`. |
+| **cpu / memory / device load / is the camera overloaded / stuttering** | **`config get performance`** | Live reading from the device: `cpuUsedPercent`, `codeRate`, `netDataRate`. Read-only and instantaneous — two calls a second apart legitimately differ. Not every model implements it; those answer a device-level rejection. Distinct from `benchmark`, which times the **client** round trip, not the camera. |
 | **rtsp / rtmp / flv address / stream URL / HA / Frigate / go2rtc / VLC** | **`stream url [--kind rtsp,rtmp,flv] [--stream main,sub,ext] [--with-auth]`** | Default `--kind rtsp --stream main`. `--with-auth` only when user explicitly wants one-shot pasteable URL. NVR: `device expand` then `--tag <nvr>`. Detail in `references/media.md`. |
 | nvr with 8 channels / RLN sub-cameras / channel N | `device expand <nvr-name> [--yes \| --names A,B,C]` | **NVR only**. Registers one entry per channel, tagged with parent name. After: `--tag <nvr-name>` fans out. |
 | **preview / take a look / watch N minutes / watch live** | **`preview play`** (opens ffplay window) | **DEFAULT to `play`, not `capture`.** User wants a live window, not a file. |

--- a/skills/reolink-cli/references/controls.md
+++ b/skills/reolink-cli/references/controls.md
@@ -13,9 +13,9 @@ reolink-cli --camera front-door light ir set --state auto    # or on / off
 reolink-cli --camera front-door light statusled get
 reolink-cli --camera front-door light statusled set --state off
 
-# Spotlight (manual on/off; see `light spotlight set --help` for --duration's
-# status, and `light spotlight blink` for repeated flashes)
-reolink-cli --camera front-door light spotlight set --enable --duration 30
+# Spotlight (manual on/off; `--duration` is deprecated — see
+# `light spotlight set --help`. For repeated flashes: `light spotlight blink`)
+reolink-cli --camera front-door light spotlight set --enable
 reolink-cli --camera front-door light spotlight set --disable
 
 # White LED alarm config

--- a/skills/reolink-cli/references/gateway-http.md
+++ b/skills/reolink-cli/references/gateway-http.md
@@ -55,6 +55,12 @@ The token supplies the device credentials server-side — **never put `user` /
 `password` in a URL**; the gateway rejects requests without a valid token.
 
 ```bash
+# Live video for a browser <video src> element
+curl -Ns "http://127.0.0.1:9000/api/preview/video?token=$TOKEN&host=192.168.1.43:9000&stream=sub"
+
+# Stop that stream
+curl -s -X POST "http://127.0.0.1:9000/api/preview/stop?token=$TOKEN"
+
 # Events NDJSON
 curl -Ns "http://127.0.0.1:9000/api/events?token=$TOKEN&types=motion,people"
 
@@ -64,6 +70,24 @@ curl -s -o /tmp/snap.jpg "http://127.0.0.1:9000/api/snapshot?token=$TOKEN&host=1
 # Recording download
 curl -s -o /tmp/clip.h264 "http://127.0.0.1:9000/api/vod/download?token=$TOKEN&host=192.168.1.43:9000&fileName=$NAME"
 ```
+
+## Dashboard Endpoints
+
+The gateway's built-in dashboard drives itself through these. They are stable
+enough to script against, but the CLI is the supported surface — reach for these
+only when you are building a UI.
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/api/health` | GET | liveness; no token required |
+| `/api/features` | GET | what this build supports (same data as `features`) |
+| `/api/cameras` | GET / POST | list the registry / add an entry |
+| `/api/discover` | GET | LAN discovery, same probes as `discover` |
+| `/api/doctor` | GET | health checks; `/api/doctor/fix` (POST) applies them |
+| `/api/recent-ops` | GET | recent operations, for the dashboard's activity list |
+
+This table and the streaming list above are the complete set the gateway
+serves. If you find one that is not here, the docs are stale — please say so.
 
 ## Response Shapes
 


### PR DESCRIPTION
A sweep of the defect classes @ch-bas has been finding, run against the code rather than waiting for the next report. It found four things, and the first one is ours to apologise for.

## We reverted a merged contribution within the hour

The `release: 0.10.6` sync copied this project's internal copies of `gateway-http.md` and `controls.md` over the public ones. The internal copies had never received #50, so the sync silently deleted:

- the `/api/preview/video` endpoint note that #50 added;
- the conflict resolution on the spotlight example — `--duration 30` came back into a command whose own comment calls the flag deprecated.

Nothing caught it. Not review, not CI, not the person running the sync. Both are restored here.

**Root cause: the skill docs live in two repositories and are mirrored by hand.** `scripts/check-docs-mirror.sh` now compares them and, importantly, names the dangerous direction — lines that exist *only* in the public copy, which a sync would delete. The release guide requires running it before the sync copy, which is the moment work gets destroyed. The real fix is one copy instead of two; this makes the divergence loud until then.

## Three genuine defects the sweep turned up

**The gateway endpoint list was a third complete.** The gateway serves 14 `/api/*` endpoints; `gateway-http.md` documented 3. Now all of them are listed, with the dashboard-facing ones in their own table, and the doc states that this is the complete set and asks to be told if it is not — a list that does not claim completeness is harmless, one that claims it falsely misleads.

**The "needs the gateway" list was wrong in the direction that costs the most.** SKILL.md said only `device *`, `config init` and `discover` work without a gateway. Verified by running each command with nothing listening: `features`, `doctor` and `cache status|clean` work fine too — and those are exactly what an agent reaches for first, so they were being gated behind a daemon they never needed.

**A stale example carried a deprecated flag** — covered above with the sync revert.

## What the sweep checked and found clean

Stated because "we looked" is worth as much as "we found":

- **74 shell blocks** across the docs: no syntax errors.
- **170 documented commands**: all parse against the real binary (`check-doc-commands.py`).
- **`cache clean` is dry-run by default** — verified by pointing it at a temp cache with three expired files and confirming all three survived a run without `--apply`.
- **The interactive password prompt behaves as documented**: a TTY prompts; a non-TTY fails with a message naming `--password-stdin` rather than silently storing nothing.
- **`--password` guidance is consistent** across README, AGENTS.md, SKILL.md and the references — all say do not put it on argv.
- **Version strings** agree across all seven manifests and the checksum file.

## The pattern, since it keeps repeating

Every defect in this sweep is the same shape as the six in #40–#50: one fact, two copies, and the copy drifted. Version numbers (sixteen places, now two), `--help` text restated in prose (now cited instead), and now the docs themselves existing twice. The checkers help, but each one only makes a specific drift loud — the thing that actually removes a class is deleting the second copy.
