### PR TITLE
release: 0.10.7

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "reolink-cli",
       "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-      "version": "0.10.6",
+      "version": "0.10.7",
       "source": "./",
       "author": {
         "name": "Reolink"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "author": {
     "name": "reolink"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "Plugin for operating Reolink cameras through the local CLI.",
   "author": {
     "name": "Reolink"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "reolink-cli",
   "displayName": "Reolink CLI",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "author": {
     "name": "Reolink"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,7 @@ All notable changes to the public `reolink-cli` distribution are documented here
 This is the customer-facing release history; it tracks the LAN-only (external)
 builds published as GitHub Releases.
 
-## [Unreleased]
-
-Becomes `## [0.10.7] — <date>` when it ships. Kept unversioned until then so
-the manifests are not carrying a version number no release uses — the daily
-version-sync check compares them against the latest published release, and a
-repository that runs ahead trips the same alarm as one that lags behind.
+## [0.10.7] — 2026-08-03
 
 ### Security
 

--- a/checksums/v0.10.7.sha256
+++ b/checksums/v0.10.7.sha256
@@ -1,0 +1,6 @@
+323c84390fb607ca566f33c56ea202d5360ad8b88437ca51e4209f4a1ad8016b  reolink-cli-0.10.7-external-darwin-arm64.tar.gz
+e677c7538445ec8ea4a3611cc3f8189e01783f258fddb8c4432176e4b828fb5e  reolink-cli-0.10.7-external-linux-arm64-musl.tar.gz
+3befb981f0d83df37e0f5fbd8daa5589d2cbc7a019d323f24f1d5758c87a96c8  reolink-cli-0.10.7-external-linux-arm64.tar.gz
+2ed87bbb4911d58b984c01331f8ecc7021e522cc05136c97d1065f2b732b6f15  reolink-cli-0.10.7-external-linux-x86_64-musl.tar.gz
+b432233f681de350229da3045da24174ba861240eac380e656f5c96c4eae53a1  reolink-cli-0.10.7-external-linux-x86_64.tar.gz
+1f91efa5112c664ed84054bb156849a03acccdd7f1dea4b88f72a87e1329655d  reolink-cli-0.10.7-external-windows-x86_64.zip

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "contextFileName": "GEMINI.md"
 }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "reolink-cli",
   "name": "Reolink CLI",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "author": {
     "name": "Reolink"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "type": "module",
   "description": "Operate Reolink cameras locally via reolink-cli.",
   "main": ".opencode/plugins/reolink-cli.js",


### PR DESCRIPTION
Version bump, CHANGELOG, and the six artifact checksums.

The checksums must land on the default branch **before** the release is published: both installers and `self-update` now fail closed when the committed checksum file is missing, so publishing first would break every one-line install until this merged.