### PR TITLE
docs: the one-line install had no documented way to uninstall

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,7 +148,23 @@ Slash commands run a single deterministic shell command — **no LLM intent mapp
 
 ## Uninstall
 
-The release tarball ships its own `uninstall.sh` / `uninstall.ps1` scripts:
+**Installed with the one-line installer?** There is no tarball, so use the
+binary's own uninstall — this is the path most installations need:
+
+```sh
+reolink-cli setup --uninstall --no-interactive --agents none
+```
+
+It stops gateways started from this install prefix, removes both binaries, and
+keeps config, aliases, cache and rules. Add `--purge` to wipe those too.
+
+On Windows it will report that it could not remove `reolink-cli.exe` and exit
+non-zero: the OS locks a running image, so the binary running the uninstall
+cannot delete itself. The message gives the one command that finishes the job.
+This is expected, not a failure of the uninstall.
+
+**Installed from the release tarball?** It ships `uninstall.sh` /
+`uninstall.ps1`, thin wrappers around the same command:
 
 ```sh
 # macOS / Linux — from inside the extracted tarball directory


### PR DESCRIPTION
Found while running the Windows paths that had never actually been executed.

The uninstall section assumed a release tarball and its `uninstall.sh`/`uninstall.ps1`. Anyone who used the one-line installer has **no tarball**, so they had no documented way to uninstall — while the binary has carried `setup --uninstall` all along. That is now the primary instruction.

It also documents the Windows behaviour instead of leaving it to be discovered: the uninstall reports that it could not remove `reolink-cli.exe` and exits non-zero, because Windows locks a running image and the binary doing the uninstalling cannot delete itself. The message carries the command that finishes the job.

Exiting non-zero there is deliberate and new — it previously exited **0** having left the main binary behind, which told every script, package manager and agent reading the exit code that the uninstall had succeeded. That fix, along with a scoping bug where uninstalling from one prefix killed every `reolink-gateway.exe` on the machine, is in the binary and ships with the next release.