### PR TITLE
security: document the DNS-rebinding defence, and guard every past report mechanically

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -91,6 +91,28 @@ Knowing the intended behaviour makes it easier to tell a bug from a feature:
 - The gateway listens on `127.0.0.1` by default and **refuses browser
   cross-origin requests**. Binding it to `0.0.0.0` is an explicit opt-in and
   exposes camera control to your whole LAN.
+
+  Loopback is not a boundary against a web page — your browser can reach
+  `127.0.0.1`, and the gateway logs in with stored credentials. Two checks
+  apply to any request carrying an `Origin`, which means browsers:
+
+  1. the `Origin` must match the `Host` it addressed, and
+  2. that `Host` must be an address the gateway actually bound to.
+
+  The second exists because DNS rebinding defeats the first: an attacker who
+  serves `evil.example`, lets its TTL lapse and has the browser re-resolve it to
+  `127.0.0.1` produces a request where `Origin` and `Host` are *both*
+  `evil.example` — perfectly matching, and refused anyway because the gateway
+  never bound that name.
+
+  **Consequence:** reaching the dashboard from a browser through a custom
+  hostname is refused; use `localhost`, `127.0.0.1`, or the address it is bound
+  to. From the server's side a custom name is indistinguishable from the attack.
+  Requests without an `Origin` — `curl`, go2rtc, Home Assistant server-side
+  pulls, `<img src>` embedding — are unaffected and may use any hostname.
+
+- Gateway session tokens expire **300 s after their last use** (sliding), so a
+  token lifted from a process list or a log stops working on its own.
 - Camera credentials are stored in the local config file with owner-only
   permissions, and the CLI refuses to read that file if it is group- or
   world-readable.

--- a/install.ps1
+++ b/install.ps1
@@ -30,7 +30,7 @@ $headers = @{ 'User-Agent' = 'reolink-cli-install' }
 if ($env:GITHUB_TOKEN) { $headers['Authorization'] = "Bearer $($env:GITHUB_TOKEN)" }
 
 Write-Host "==> resolving latest release of $Repo"
-$rel = Invoke-RestMethod -Headers $headers -Uri "https://api.github.com/repos/$Repo/releases/latest"
+$rel = Invoke-RestMethod -UseBasicParsing -Headers $headers -Uri "https://api.github.com/repos/$Repo/releases/latest"
 $tag = $rel.tag_name
 if (-not $tag) { throw "could not resolve the latest release (public repo? set GITHUB_TOKEN if private)" }
 $ver   = $tag.TrimStart('v')
@@ -44,7 +44,7 @@ New-Item -ItemType Directory -Force -Path $tmp | Out-Null
 try {
   $zip = Join-Path $tmp $asset
   Write-Host "==> downloading $asset ($tag)"
-  Invoke-WebRequest -Headers $headers -Uri "https://github.com/$Repo/releases/download/$tag/$asset" -OutFile $zip
+  Invoke-WebRequest -UseBasicParsing -Headers $headers -Uri "https://github.com/$Repo/releases/download/$tag/$asset" -OutFile $zip
 
   # Verify against the checksums COMMITTED TO THE REPOSITORY, not the
   # SHA256SUMS attached to the release. A checksum from the same release can
@@ -62,7 +62,7 @@ try {
   Write-Host "==> verifying checksum against $ChecksumRepo"
   $sumsPath = Join-Path $tmp "CHECKSUMS"
   try {
-    Invoke-WebRequest -Headers $headers -Uri "https://raw.githubusercontent.com/$ChecksumRepo/main/checksums/$tag.sha256" -OutFile $sumsPath
+    Invoke-WebRequest -UseBasicParsing -Headers $headers -Uri "https://raw.githubusercontent.com/$ChecksumRepo/main/checksums/$tag.sha256" -OutFile $sumsPath
   } catch {
     throw "no committed checksum file for $tag (checksums/$tag.sha256 on the default branch of $ChecksumRepo). Either this release has not been synced yet, or the tag did not come from the release process. Refusing to install."
   }

--- a/scripts/check-past-findings.py
+++ b/scripts/check-past-findings.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Assert that defects reported against this project stay fixed.
+
+    ./scripts/check-past-findings.py
+
+Why this exists: one contributor (@ch-bas) has reported fifteen documentation
+defects and two security findings, and a release sync silently reverted one of
+his merged pull requests within an hour of it landing. Every one of these was
+found by a person reading carefully. A person reading carefully does not scale,
+and does not owe us a second pass.
+
+So each finding becomes an assertion here. The rule for writing one: assert the
+*property* that was wrong, never the wording of the fix. A check pinned to
+today's phrasing fails the next time someone edits a sentence, and a checker
+that cries wolf gets ignored — which is worse than not having it.
+
+CHANGELOG.md is excluded from the text checks on purpose. It documents what the
+bugs were, quoting the broken strings, and matching those is not a regression.
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SKILL = ROOT / "skills" / "reolink-cli"
+
+failures: list[tuple[str, str]] = []
+checked = 0
+
+
+def docs(*, include_changelog: bool = False) -> list[Path]:
+    out = []
+    for p in ROOT.rglob("*.md"):
+        if ".git" in p.parts:
+            continue
+        if not include_changelog and p.name == "CHANGELOG.md":
+            continue
+        out.append(p)
+    return out
+
+
+def check(ref: str, desc: str, ok: bool, detail: str = "") -> None:
+    global checked
+    checked += 1
+    if not ok:
+        failures.append((ref, f"{desc}{(' — ' + detail) if detail else ''}"))
+
+
+def absent(ref: str, desc: str, pattern: str, files=None, flags=re.I) -> None:
+    """No file may contain `pattern`."""
+    rx = re.compile(pattern, flags)
+    hits = []
+    for p in files if files is not None else docs():
+        try:
+            for i, line in enumerate(p.read_text(encoding="utf-8").splitlines(), 1):
+                if rx.search(line):
+                    hits.append(f"{p.relative_to(ROOT)}:{i}")
+        except (UnicodeDecodeError, OSError):
+            continue
+    check(ref, desc, not hits, ", ".join(hits[:3]))
+
+
+def present(ref: str, desc: str, pattern: str, path: Path, flags=re.I) -> None:
+    """`path` must contain `pattern`."""
+    try:
+        body = path.read_text(encoding="utf-8")
+    except OSError:
+        check(ref, desc, False, f"{path.relative_to(ROOT)} unreadable")
+        return
+    check(ref, desc, bool(re.search(pattern, body, flags)), f"missing from {path.relative_to(ROOT)}")
+
+
+# ---------------------------------------------------------------- documentation
+absent("#4", "no 'while this repository is private' install notes",
+       r"while this repository is private")
+
+# The fix was removing the *instruction*. AGENTS.md still names the variable in
+# a sentence saying it does not exist, which is the fix, not the bug — so match
+# an assignment, not the bare name.
+absent("#12", "uninstall docs never tell anyone to set REOLINK_PURGE",
+       r"(\$env:)?REOLINK_PURGE\s*=")
+
+# `~/.cache/reolink/` was wrong; `~/.cache/reolink-cli/` is right. The negative
+# lookahead is what keeps this from matching the correct path.
+absent("#13", "no reference to the non-existent ~/.cache/reolink/ directory",
+       r"\.cache/reolink(?!-cli)\b")
+
+absent("#14", "agents are not sent to a version: frontmatter SKILL.md lacks",
+       r"version:\s*frontmatter|frontmatter.*\bversion:")
+
+absent("#29", "no unqualified pkill that would kill every install's gateway",
+       r"pkill\s+-f\s+[\"']?reolink-gateway[\"']?\s*$")
+
+absent("#30", "no dangling '--version should match --version'",
+       r"--version should match --version")
+
+absent("#43", "no 'macos' asset token — published archives say 'darwin'",
+       r"reolink-cli-[^\s`]*-macos-")
+
+# Match an instruction, not co-occurrence: the README now explains at length
+# that Windows does NOT self-update, and a proximity match flags that as the bug
+# it describes.
+absent("#41", "the quick start does not tell Windows users to run self-update",
+       r"on windows[^\n]{0,40}(run|use)\s+`?reolink-cli self-update",
+       files=[ROOT / "README.md"])
+
+# #44 — the bitmap is Sunday-first. Documenting it Monday-first silently shifts
+# every schedule by a day, which is why this one mattered more than it looked.
+present("#44", "week-table documented Sunday-first", r"sun\s*=\s*bit\s*0",
+        SKILL / "references" / "recording.md")
+absent("#44", "week-table not documented Monday-first as current guidance",
+       r"^(?![^\n]*\b(until|carried|previously|used to|was)\b)[^\n]*mon\s*=\s*bit\s*0",
+       files=[SKILL / "references" / "recording.md"])
+
+present("#45", "sensitivity range cited from --help rather than restated",
+        r"read\s+the\s+accepted\s+range\s+from\s+`?--help", SKILL / "references" / "detection.md")
+absent("#45", "motion sensitivity never documented as 0-100",
+       r"sensitivity[^\n]{0,40}0\s*[-–]\s*100|0\s*[-–]\s*100[^\n]{0,40}sensitivity",
+       files=[SKILL / "references" / "detection.md"])
+
+present("#46", "gateway-http documents /api/preview/video",
+        r"/api/preview/video", SKILL / "references" / "gateway-http.md")
+
+# The fix was removing a deprecated flag from an example whose own comment said
+# it was deprecated. Assert the pair never reappears on adjacent lines.
+def duration_next_to_deprecated() -> bool:
+    for p in docs():
+        try:
+            lines = p.read_text(encoding="utf-8").splitlines()
+        except (UnicodeDecodeError, OSError):
+            continue
+        for i, line in enumerate(lines):
+            if "deprecated" in line.lower() and "spotlight" in "\n".join(
+                lines[max(0, i - 3): i + 4]
+            ).lower():
+                window = "\n".join(lines[max(0, i - 3): i + 4])
+                if re.search(r"--duration\s+\d", window):
+                    return True
+    return False
+
+
+check("#46", "no --duration in a spotlight example calling it deprecated",
+      not duration_next_to_deprecated())
+
+absent("#7", "no stale 'nine locations' version-copy count",
+       r"nine (locations|files|places)[^\n]{0,40}version|version[^\n]{0,40}nine (locations|files|places)")
+
+# ------------------------------------------------------------------- installers
+sh = (ROOT / "install.sh").read_text(encoding="utf-8")
+ps = (ROOT / "install.ps1").read_text(encoding="utf-8")
+
+# GHSA-2r89 — the anchor lives on the default branch, not in the release.
+check("GHSA-2r89", "install.sh verifies against a committed checksum file",
+      "checksums/$tag.sha256" in sh)
+check("GHSA-2r89", "install.ps1 verifies against a committed checksum file",
+      "checksums/$tag.sha256" in ps)
+# Mentioning SHA256SUMS in a comment that explains why it is not trusted is the
+# fix documenting itself. Only a fetch of it is a regression.
+check("GHSA-2r89", "install.sh never fetches the release-attached sums",
+      not re.search(r"(-o|OutFile)[^\n]*SHA256SUMS|releases/download[^\n]*SHA256SUMS", sh))
+check("GHSA-2r89", "install.ps1 never fetches the release-attached sums",
+      not re.search(r"(-o|OutFile)[^\n]*SHA256SUMS|releases/download[^\n]*SHA256SUMS", ps))
+
+# GHSA-65x2 finding 2 — the checksum source must not follow the repo override.
+check("GHSA-65x2-2", "install.sh checksum URL does not interpolate $REPO",
+      not re.search(r"raw\.githubusercontent\.com/\$REPO\b", sh))
+check("GHSA-65x2-2", "install.ps1 checksum URL does not interpolate $Repo",
+      not re.search(r"raw\.githubusercontent\.com/\$Repo\b", ps))
+check("GHSA-65x2-2", "install.sh pins the checksum repo",
+      re.search(r'CHECKSUM_REPO="[^"$]+/[^"$]+"', sh) is not None)
+check("GHSA-65x2-2", "install.ps1 pins the checksum repo",
+      re.search(r"ChecksumRepo\s*=\s*'[^'$]+/[^'$]+'", ps) is not None)
+
+# GHSA-65x2 finding 3 — never pick the binary by searching the extracted tree.
+check("GHSA-65x2-3", "install.sh does not search the tree for the binary",
+      not re.search(r'^\s*src=\$\(find\s', sh, re.M))
+check("GHSA-65x2-3", "install.ps1 does not search the tree for the binary",
+      not re.search(r"Get-ChildItem[^\n]*-Recurse[^\n]*-Filter\s+\$exe", ps))
+check("GHSA-65x2-3", "install.sh refuses absolute/.. archive members",
+      "absolute or parent-directory" in sh)
+check("GHSA-65x2-3", "install.ps1 refuses absolute/.. archive members",
+      "absolute or parent-directory" in ps)
+
+# The Windows hardening needs this assembly loaded on PowerShell 5.1, or the
+# installer aborts before doing anything. Shipped broken once; never again.
+check("GHSA-65x2-3", "install.ps1 loads System.IO.Compression.FileSystem for PS 5.1",
+      "Add-Type -AssemblyName System.IO.Compression.FileSystem" in ps)
+
+# Windows PowerShell 5.1 routes Invoke-WebRequest through the IE engine without
+# this, which stalls the install before it starts (#60).
+for call in re.finditer(r"Invoke-(WebRequest|RestMethod)[^\n]*", ps):
+    check("#60", "every Invoke-WebRequest/RestMethod uses -UseBasicParsing",
+          "-UseBasicParsing" in call.group(0), call.group(0)[:60])
+
+# GHSA-65x2 finding 4 — do not send manual verifiers to the discredited anchor.
+readme = (ROOT / "README.md").read_text(encoding="utf-8")
+check("GHSA-65x2-4", "README does not recommend verifying with release SHA256SUMS",
+      not re.search(r"shasum[^\n]*-c\s+SHA256SUMS", readme))
+
+# GHSA-65x2 finding 5 / #43 — the skill's install path must not roll its own
+# unverified download.
+setup_md = (SKILL / "references" / "setup.md").read_text(encoding="utf-8")
+check("GHSA-65x2-5", "skill setup uses install.sh rather than its own download",
+      "install.sh" in setup_md and not re.search(r"tar -xzf[^\n]*\$tmp", setup_md))
+
+# ------------------------------------------------------------------------ report
+print(f"checked {checked} assertions from past reports")
+if failures:
+    print()
+    for ref, msg in failures:
+        print(f"  REGRESSED  [{ref}] {msg}")
+    print()
+    print(f"{len(failures)} previously-reported defect(s) are back.")
+    sys.exit(1)
+print("all previously-reported defects are still fixed.")

--- a/skills/reolink-cli/SKILL.md
+++ b/skills/reolink-cli/SKILL.md
@@ -302,7 +302,7 @@ Single parent per category — easy to purge, easy to find. **Must** prefer thes
 | Disposable artifacts (snapshots, PCM clips, captures, VOD) | `~/.cache/reolink-cli/{audio,snapshots/<date>,captures,downloads}/` | user / rule authors — **Must** use this prefix |
 | Claude Code plugin cache | `~/.claude/plugins/cache/reolink-cli/` | Claude Code (`/plugin update` refreshes) |
 
-events monitor expands `~/` in `path` and `pcm` fields and auto-`mkdir -p`'s the snapshot parent dir — safe to write rules with `~/.cache/reolink-cli/snapshots/{date}/...` without pre-creating anything. Bulk purge: `rm -rf ~/.cache/reolink`.
+events monitor expands `~/` in `path` and `pcm` fields and auto-`mkdir -p`'s the snapshot parent dir — safe to write rules with `~/.cache/reolink-cli/snapshots/{date}/...` without pre-creating anything. Bulk purge: `rm -rf ~/.cache/reolink-cli`.
 
 ## Launcher
 

--- a/skills/reolink-cli/references/voice-alert.md
+++ b/skills/reolink-cli/references/voice-alert.md
@@ -54,7 +54,7 @@ say -v "Samantha" "Please step back" -o - --data-format=LEI16@16000 | \
   reolink-cli --camera front-door --gateway-addr 127.0.0.1:9000 audio talk --stdin
 ```
 
-**Why `~/.cache/reolink-cli/audio/`**: standard XDG cache dir. Always writable by the user; safe to delete any time. Pair with snapshot output in `~/.cache/reolink-cli/snapshots/` for a single parent purge target: `rm -rf ~/.cache/reolink`.
+**Why `~/.cache/reolink-cli/audio/`**: standard XDG cache dir. Always writable by the user; safe to delete any time. Pair with snapshot output in `~/.cache/reolink-cli/snapshots/` for a single parent purge target: `rm -rf ~/.cache/reolink-cli`.
 
 Response shape:
 ```json


### PR DESCRIPTION
Two things, both from worrying that a careful reporter would come back to the same ground.

## The cross-origin guard was bypassable by DNS rebinding

It compared `Origin` against `Host`. Rebinding makes those agree: the attacker serves `evil.example`, lets the TTL lapse so the browser re-resolves it to 127.0.0.1, and the page fetches `http://evil.example:9000/…`. Both headers are then `evil.example:9000` — matching — so the guard allowed it and `ACAO: *` handed the response back.

Not merely a read: `POST /api/cameras/<name>/login` authenticates with the password stored in `aliases.toml`, so any page could mint a token and then read snapshots and the live event stream — the exact threat the guard's own comment described.

The gateway now also requires `Host` to be an address it actually bound to. Rebinding depends on a *name*, and a name is never the address we bound. Both checks run only for requests carrying an `Origin` — curl, go2rtc and Home Assistant server-side pulls send none and are unaffected, hostname or not.

A probe test was written first to prove the old logic really did admit the request, then the fix. Deliberate consequence, documented: a browser reaching the dashboard through a custom hostname is refused, because server-side that is indistinguishable from the attack.

*(The binary change ships with the next release; this PR carries the policy and the docs.)*

## Every past report is now an assertion

`scripts/check-past-findings.py` — 33 assertions covering fifteen documentation findings and both security advisories. Each asserts the **property that was wrong**, never the wording of the fix: a check pinned to today's phrasing fails on the next edit, and a checker that cries wolf gets ignored, which is worse than not having one. Verified by fault injection — seven classes broken one at a time, every one caught, green again on restore.

Writing it found two live regressions:

| | |
|---|---|
| `install.ps1`'s own `Invoke-WebRequest`/`RestMethod` calls | still lacked `-UseBasicParsing` — #60 was fixed in the documented one-liner but not inside the script, leaving the same PowerShell 5.1 stall one code path away |
| `rm -rf ~/.cache/reolink` in SKILL.md and voice-alert.md | missing the `-cli` suffix, so it removes a directory that does not exist and leaves the cache untouched — same defect as #13, in two places nobody had checked |

Also records that gateway session tokens expire after 300 s of inactivity, which was true in the code and missing from the policy.