### PR TITLE
security: keep GITHUB_TOKEN off argv, and stop the checksum check passing on an unreadable file

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -77,8 +77,21 @@ if [ "$os" = linux ]; then
 fi
 
 # Optional bearer token (private repo only); public access is anonymous.
-AUTH=""
-[ -n "${GITHUB_TOKEN:-}" ] && AUTH="Authorization: Bearer $GITHUB_TOKEN"
+#
+# The header goes to curl on **stdin**, never on the command line. argv is
+# world-readable through `ps`, so any other user on the machine could lift
+# GITHUB_TOKEN for as long as the request runs. `self_update.rs` already refuses
+# to do this and says why; this script was doing the opposite at three call
+# sites, in the same project, against the same threat.
+#
+# `printf | curl` rather than a heredoc on curl's own stdin: this script is
+# routinely run as `curl … | sh`, where the shell's stdin *is* the script. A
+# command that reads stdin there would eat the rest of the script.
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  curl_gh() { printf 'Authorization: Bearer %s\n' "$GITHUB_TOKEN" | curl -H @- "$@"; }
+else
+  curl_gh() { curl "$@"; }
+fi
 
 if [ "$REPO" != "$CHECKSUM_REPO" ]; then
   say "note: downloading from $REPO, but verifying against checksums committed to"
@@ -87,7 +100,7 @@ if [ "$REPO" != "$CHECKSUM_REPO" ]; then
 fi
 
 say "==> resolving latest release of $REPO"
-tag=$(curl -fsSL -A reolink-cli-install ${AUTH:+-H "$AUTH"} \
+tag=$(curl_gh -fsSL -A reolink-cli-install \
   "https://api.github.com/repos/$REPO/releases/latest" \
   | sed -n 's/.*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)
 [ -n "$tag" ] || die "could not resolve the latest release (is the repo public? set GITHUB_TOKEN if it is private)"
@@ -106,7 +119,7 @@ case "$arch" in
   *-musl) hint="
 musl archives start at v0.10.7; earlier releases published glibc builds only." ;;
 esac
-curl -fSL -A reolink-cli-install ${AUTH:+-H "$AUTH"} \
+curl_gh -fSL -A reolink-cli-install \
   -o "$tmp/pkg.tar.gz" "https://github.com/$REPO/releases/download/$tag/$asset" \
   || die "download failed — see https://github.com/$REPO/releases$hint"
 
@@ -131,7 +144,7 @@ curl -fSL -A reolink-cli-install ${AUTH:+-H "$AUTH"} \
 # An attacker who can commit to that repository's default branch can publish a
 # matching pair. Nothing here defends against that — see SECURITY.md.
 say "==> verifying checksum against $CHECKSUM_REPO"
-curl -fsSL -A reolink-cli-install ${AUTH:+-H "$AUTH"} \
+curl_gh -fsSL -A reolink-cli-install \
      -o "$tmp/CHECKSUMS" "https://raw.githubusercontent.com/$CHECKSUM_REPO/main/checksums/$tag.sha256" 2>/dev/null \
   || die "no committed checksum file for $tag (checksums/$tag.sha256 on the default branch of $CHECKSUM_REPO).
 Either this release has not been synced yet, or the tag did not come from the

--- a/scripts/check-version-sync.sh
+++ b/scripts/check-version-sync.sh
@@ -225,7 +225,17 @@ for a in d.get("assets", []):
     done <<EOF
 $(sed -n 's/^\([0-9a-f]\{64\}\)[[:space:]][[:space:]]*[*]\{0,1\}\(.*\)$/\1 \2/p' "checksums/v${want}.sha256")
 EOF
-    if [ "$mism" -eq 0 ]; then
+    if [ "$checked" -eq 0 ]; then
+      # Zero entries is not agreement, it is an unreadable file. The check used
+      # to print a green "0 assets match what is served" for a checksums file
+      # whose contents no longer parse — while every one-line install using it
+      # would fail closed, because the installer finds no entry for its asset.
+      # A checker that reports success for the state it exists to catch is worse
+      # than no checker.
+      printf '  MISMATCH  %-46s no parseable entries — installs FAIL CLOSED\n' \
+        "checksums/v${want}.sha256"
+      fail=1
+    elif [ "$mism" -eq 0 ]; then
       printf '  ok        %-46s %s assets match what is served\n' "committed hashes vs release" "$checked"
     else
       fail=1


### PR DESCRIPTION
Two findings from an adversarial audit run through the reporting contributor's methodology. Both are the project disagreeing with itself.

**`GITHUB_TOKEN` was on curl's command line** at three call sites in `install.sh`. `self_update.rs` refuses to do exactly that and explains why in a comment: argv is world-readable through `ps`, so any other local user can lift the token for as long as the request runs. Same project, same threat, opposite answers — with the reasoning already written down on one side.

The header now goes to curl on stdin. It is fed by `printf | curl` rather than curl reading the script's own stdin, because this file is routinely run as `curl … | sh` where the shell's stdin **is** the script; a command reading from it would eat the rest of the install.

Verified against the live release:

| path | result |
|---|---|
| no token (normal public install) | installs 0.10.7, checksum verified |
| deliberately invalid token | GitHub returns 401 — which is itself the proof the header is being sent |

**`check-version-sync.sh` passed on an unreadable anchor.** For a checksums file whose contents no longer parse it printed `ok  committed hashes vs release  0 assets match what is served` and the run went green. Zero entries is not agreement — it is an unreadable anchor, and every one-line install using it fails closed because the installer finds no entry for its asset. A checker that reports success for the exact state it exists to catch is worse than not having one.

Now a MISMATCH, verified by injecting a corrupt file (run fails), then restoring (run green).