### PR TITLE
fix: devices slash command pointed at the legacy ~/.config/reolink path

### DIFF
--- a/commands/devices.md
+++ b/commands/devices.md
@@ -1,5 +1,5 @@
 ---
-description: List registered Reolink aliases (from ~/.config/reolink/aliases.toml)
+description: List registered Reolink aliases (from ~/.config/reolink-cli/aliases.toml)
 ---
 
 Run `reolink-cli device list --output json` and print each alias on one line as:


### PR DESCRIPTION
## What changes

The `/reolink-cli:devices` slash command described the registry as living at `~/.config/reolink/aliases.toml`, but the tool's config directory is `~/.config/reolink-cli/` — `reolink/` is the legacy, migrated-away path (`doctor` labels it "legacy reolink/ dirs … clean post-migration"). Corrected the description to `~/.config/reolink-cli/aliases.toml`.

This is the repo-side half of #68. The binary-generated config template still names `reolink/` too, but that string is compiled into the binary and can only be fixed upstream (tracked in #68); this PR fixes the one instance that lives in this repository.

## How it was verified

Grepped the whole repo after the change: `commands/devices.md` was the last doc still using the `reolink/` path — every other reference (AGENTS.md, SKILL.md, uninstall.md, the reference docs) already uses `reolink-cli/`. Frontmatter-only change to a slash-command description; no command behavior affected.

## Checklist

- [x] No password, camera UID, or private network address appears in the diff
- [x] Docs updated if a flag, output field, or default changed
- [ ] `cargo test --workspace` passes — N/A: this repo contains no Rust source; slash-command doc only
