### PR TITLE
docs(changelog): 0.11.0 fixes six reported issues, not five

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ builds published as GitHub Releases.
 
 ## [0.11.0] — 2026-08-06
 
-Five reported issues, two new platforms, and one command that could delete your
+Six reported issues, two new platforms, and one command that could delete your
 installation without asking.
 
 ### Added


### PR DESCRIPTION
The count in the 0.11.0 heading was written before #72 was folded into the release. The entry below it lists #68, #69, #70, #72, #73 and #74 — six.