### PR TITLE
release: 0.13.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "reolink-cli",
       "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "source": "./",
       "author": {
         "name": "Reolink"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "author": {
     "name": "reolink"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Plugin for operating Reolink cameras through the local CLI.",
   "author": {
     "name": "Reolink"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "reolink-cli",
   "displayName": "Reolink CLI",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "author": {
     "name": "Reolink"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,68 @@ All notable changes to the public `reolink-cli` distribution are documented here
 This is the customer-facing release history; it tracks the LAN-only (external)
 builds published as GitHub Releases.
 
+## [0.13.1] — 2026-08-24
+
+Three bugs reported against 0.13.0, plus two more `vod download` defects found
+while verifying the fixes against a real Home Hub 2, and a large speed-up for
+batch downloads.
+
+### Fixed
+
+- **`vod download` silently dropped everything past about the 210th recording**
+  (#87, reported by **@djancak**). The recording names travel in the request
+  URL, and the gateway cut that URL off at 4096 bytes without saying so — then
+  served the shortened request as if nothing had happened, reporting `ok: true`
+  for a download that fetched 210 of 394 files.
+
+  The gateway now answers `414 URI Too Long` instead of truncating, and the CLI
+  splits a long list into as many requests as it takes, each sized against the
+  real encoded length. Recordings in one batch still share a single device
+  connection, so the speed-up from 0.12.4 (#72) is intact. Verified on a Home
+  Hub 2: 220 recordings requested, 220 written.
+
+- **A camera registered with a `uid` could not be reached at all** (#85,
+  reported by **@djancak**). Since these builds carry no P2P, a `uid` target
+  went straight to a wake broadcast — ignoring the LAN address the same entry
+  already gave — and a mains-powered camera that never answers a wake failed
+  after about nine seconds with `wake timed out after 3 attempts`. A camera
+  that did answer would then have been logged in with the wrong protocol.
+
+  A `uid` target now tries the LAN first: an entry that also carries a `host`
+  connects straight to it, and the wake path is left to the battery devices it
+  was meant for. Verified against a real camera: 9.0s failure → 2.1s success.
+
+- **`vod download` could not fetch any recording past the 500th of its day.**
+  Locating a recording by name re-searched its day with a hard cap of 500, so
+  on a busy day `vod search` would list a recording that `vod download` then
+  reported as `not found`. Measured on a Home Hub 2 with 604 recordings in one
+  day. The cap is gone — that search looks for one known name, so capping it
+  protected nothing.
+
+- **Long multi-recording downloads failed near the end with `invalid or expired
+  token`.** A media token expires 300 seconds after its last use, and a batch of
+  a few hundred recordings streams for far longer than that. Each batch now gets
+  a fresh token.
+
+### Changed
+
+- **`vod search --limit` accepts up to 100000, and `--limit 0` means no limit**
+  (#86, reported by **@djancak**). The old ceiling of 500 was never a camera
+  limit — the request carries no count at all and the camera pages until it runs
+  out — and a single busy day can exceed it, leaving no way to tell "this camera
+  has 500 recordings" from "we stopped counting at 500". A day with 604 and a
+  month with 965 both come back whole now.
+
+### Performance
+
+- **Batch `vod download` is several times faster.** Locating each recording
+  searched its entire day and then filtered by name; a recording's name already
+  ends in its own start time, so the search now asks for that one second and
+  falls back to the day only if that finds nothing. On a Home Hub 2 a day
+  holding 604 recordings took 4.97s to search and one second of it 0.31s, and
+  this runs once per file. Same 220 recordings, same camera: 360s → 204s, and
+  roughly six times faster on days with more recordings in them.
+
 ## [0.13.0] — 2026-08-21
 
 Two new command groups — video encoder settings and the manual siren — plus a

--- a/checksums/v0.13.1.sha256
+++ b/checksums/v0.13.1.sha256
@@ -1,0 +1,8 @@
+745cfb6bb10ae41e680d4baa2decc506cdf8b12882b02484798a8a4b4507b6f6  reolink-cli-0.13.1-external-darwin-arm64.tar.gz
+5380fc6a2765cb3a4ada9621604b763cbfb9802966a37fd57fcd423001c6e111  reolink-cli-0.13.1-external-linux-arm64-musl.tar.gz
+7888131a8138d38b706785c3e41192fa2bb4f8953270b09ca161f4c8019af1da  reolink-cli-0.13.1-external-linux-arm64.tar.gz
+d177a79486f05b876cf089b368c17c257d08f829a45e5bfbda607fb0fcc1a9db  reolink-cli-0.13.1-external-linux-armv6.tar.gz
+310ebfe68aeb50c2c991518746bbdae2892892b8180bb610776a22349d14da1b  reolink-cli-0.13.1-external-linux-armv7.tar.gz
+e5beba7d56577bc5fea75acabdd3fb83985ae2b307cadc4e7ab10f441b19dac7  reolink-cli-0.13.1-external-linux-x86_64-musl.tar.gz
+e5c7faed434439eca7852826a21cd759fd33a443a7ea9442e6b2cfd34a023899  reolink-cli-0.13.1-external-linux-x86_64.tar.gz
+204ab97735ee73b62ec4b4f53a93d2ff264617675628fc394f2241d24cf9361e  reolink-cli-0.13.1-external-windows-x86_64.zip

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "contextFileName": "GEMINI.md",
   "mcpServers": {
     "reolink": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "reolink-cli",
   "name": "Reolink CLI",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "author": {
     "name": "Reolink"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "type": "module",
   "description": "Operate Reolink cameras locally via reolink-cli.",
   "main": ".opencode/plugins/reolink-cli.js",


### PR DESCRIPTION
Release sync for **0.13.1**.

Lands `checksums/v0.13.1.sha256` **before** the release is published — the
one-line installers resolve the latest release and then look for its checksum
file here, and they fail closed. A checksum file for a tag that does not exist
yet harms nothing; the other order breaks `curl | sh` for everyone in between.

### What is in 0.13.1

Three issues reported against 0.13.0 by @djancak:

- **#87** — `vod download` silently dropped everything past about the 210th
  recording. Recording names travel in the request URL and the gateway cut that
  URL off at 4096 bytes without saying so, then served the shortened request as
  a success. It now answers `414 URI Too Long`, and the CLI splits a long list
  into as many requests as it takes.
- **#85** — a camera registered with a `uid` could not be reached at all in
  these builds. A `uid` target went straight to a wake broadcast and ignored the
  LAN address the same entry already carried. It now tries the LAN first.
- **#86** — `vod search --limit` accepts up to 100000 and `--limit 0` means no
  limit. The old ceiling of 500 was never a camera limit, and one busy day can
  exceed it.

Two more defects surfaced while verifying #87 against a real Home Hub 2:

- `vod download` could not fetch any recording past the 500th of its day —
  locating a recording by name re-searched its day with a hard cap of 500.
- Long multi-recording downloads failed near the end with `invalid or expired
  token`; a media token expires 300s after its last use and a few hundred
  recordings stream for longer than that. Each batch now mints a fresh one.

And a performance change: locating a recording searched its whole day, but a
recording's name already ends in its own start time, so the search now asks for
that one second and falls back to the day only when that finds nothing. Same
220 recordings on the same camera: 360s → 204s.

### Verification

- All eight external artifacts built; the P2P fingerprint gate reports
  `clean (external)` for every one.
- `reolink-cli --version` → `0.13.1 (external · LAN-only)`.
- Checksums recomputed independently from the archives and matched against the
  per-artifact sidecars, 8/8.
- Fixes verified against a real Reolink Home Hub 2, not only unit tests:
  220-recording download completes 220/220, `--limit 0` returns 965 recordings
  where 500 used to truncate, and the `uid` failure reproduces at 9.0s before
  the fix and succeeds at 2.1s after.
- `./scripts/check-version-sync.sh --self` passes.

The installer end-to-end runs (macOS + Alpine on both architectures) come after
the release is published, since they resolve the latest release.
