### PR TITLE
release: 0.14.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "reolink-cli",
       "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "source": "./",
       "author": {
         "name": "Reolink"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "author": {
     "name": "reolink"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Plugin for operating Reolink cameras through the local CLI.",
   "author": {
     "name": "Reolink"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "reolink-cli",
   "displayName": "Reolink CLI",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "author": {
     "name": "Reolink"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,66 @@ All notable changes to the public `reolink-cli` distribution are documented here
 This is the customer-facing release history; it tracks the LAN-only (external)
 builds published as GitHub Releases.
 
+## [0.14.1] — 2026-08-28
+
+Three defects reported by users of 0.14.0, plus a documentation gap that took
+someone hitting an error to find.
+
+### Fixed
+
+- **Downloaded recordings were always named `.h264`, whatever the codec**
+  (#94, reported by **@djancak**). The extension was wrong twice over: those
+  files are not an elementary stream at all, they are an **MP4 container**.
+  Every one begins `…ftyp iso4`, which is why `ffprobe` reads them happily and
+  reports `hevc`.
+
+  The old code assumed the bytes after the header frame were raw H.264/H.265
+  and sniffed for Annex-B start codes. An MP4 header happens to contain a
+  `00 00 00 01`, so the sniffer read a meaningless NAL type and fell back to
+  its `h264` default — which is why *every* download got that name regardless
+  of what was inside. It now identifies the container first and names the file
+  `<recording>.mp4`; the Annex-B sniffing stays as a fallback for firmware that
+  really does send an elementary stream.
+
+- **`--password-stdin` hung on a terminal, and did not exist where it was
+  advised** (#92, reported by **@djancak**). It went straight to a blocking
+  read with nothing on screen, which is indistinguishable from a hang. It now
+  says what it is waiting for first:
+
+  ```
+  reading the password from stdin — type it, press Enter, then Ctrl-D
+  ```
+
+  That wording is measured, not assumed: on a line-buffered terminal a single
+  Ctrl-D after the password does **not** end the read, because Ctrl-D only
+  signals EOF when the line buffer is already empty.
+
+  The flag is also global now, like `--password` has always been. Previously it
+  existed only on `device add` / `device update`, while every other command's
+  error message advised "use `--password-stdin`" — advice that could not be
+  followed.
+
+### Added
+
+- **`vod download --directory <DIR>`** (#93, requested by **@djancak**).
+  Chooses where recordings land, creating the directory if it does not exist,
+  for a single recording or a list. Previously the only way was to `cd` first,
+  which a caller that does not control its working directory — an MCP client,
+  an agent — cannot do. `--file` remains single-recording-only and the two are
+  mutually exclusive.
+
+### Documentation
+
+- **Camera names with spaces** (#91, reported by **@ian1182**). There are no
+  name rules — spaces, mixed case and non-ASCII all work — but a name with a
+  space needs shell quotes like any other argument, and every example showed
+  the hyphenated form. `device add --help`, the command reference and the
+  bundled skill now show a quoted example and note that names match exactly, so
+  `Front Door` and `front door` are different cameras.
+
+Verified against a real Reolink Home Hub 2 (v3.3.0.579), including the terminal
+behaviour of `--password-stdin` under a pty.
+
 ## [0.14.0] — 2026-08-26
 
 Scene mode: the Home / Away / Disarm control your hub shows in the app, now on

--- a/checksums/v0.14.1.sha256
+++ b/checksums/v0.14.1.sha256
@@ -1,0 +1,8 @@
+c00b6a03af50e6b66c811d29c9f95e17dba952172279fb6eed1ff22f0302cfe8  reolink-cli-0.14.1-external-darwin-arm64.tar.gz
+4172822390a1d62428a0607be45f897b392c1f5dc2cefdcc0f6839d2e8b92b19  reolink-cli-0.14.1-external-linux-arm64-musl.tar.gz
+e360c535a34deb108bcdd2f2e049064d65575813c54296d23ae5a323c8e5bde3  reolink-cli-0.14.1-external-linux-arm64.tar.gz
+fbf73ee33c02cee06c5bc217203d248ef3a124bae782d2cc3377641d385a1d30  reolink-cli-0.14.1-external-linux-armv6.tar.gz
+4d29f1e657740b903fde312b0ea75489dd0bc1ca0213cf64a3cf3a70948a1a66  reolink-cli-0.14.1-external-linux-armv7.tar.gz
+1d750eafca2279430dc017872cd0d723bea7995593af69de7066f75be70cd347  reolink-cli-0.14.1-external-linux-x86_64-musl.tar.gz
+6e553fef1d96af42ddb482f7063521a972bfc3abafefbdfeba4c6bb21ae44c7e  reolink-cli-0.14.1-external-linux-x86_64.tar.gz
+f18e23c39a3504287c5b7b1dcb8d406c0ffd96be393268d2672929c15990c9a3  reolink-cli-0.14.1-external-windows-x86_64.zip

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "contextFileName": "GEMINI.md",
   "mcpServers": {
     "reolink": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "reolink-cli",
   "name": "Reolink CLI",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "author": {
     "name": "Reolink"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "type": "module",
   "description": "Operate Reolink cameras locally via reolink-cli.",
   "main": ".opencode/plugins/reolink-cli.js",

--- a/skills/reolink-cli/references/setup.md
+++ b/skills/reolink-cli/references/setup.md
@@ -112,6 +112,15 @@ reolink-cli --tag outdoor device resolve
 
 # Add (prompts for password interactively — do NOT pass --password on argv)
 reolink-cli device add front-door --host 192.168.1.43 --user admin --tags outdoor,entrance
+reolink-cli device add "front door" --host 192.168.1.41 --user admin --password-stdin
+```
+
+A name with a space needs quotes, like any shell argument — without them the
+shell splits it and the second word arrives as an unexpected argument. Names
+match exactly, so `Front Door` and `front door` are two different cameras. The
+hyphen in `front-door` is only there to save the quotes later.
+
+```bash
 
 # Update / remove
 reolink-cli device update front-door --description "Front door camera"


### PR DESCRIPTION
Release sync for **0.14.1**.

Lands `checksums/v0.14.1.sha256` **before** the release is published — the
one-line installers resolve the latest release and then look for its checksum
file here, and they fail closed. A checksum file for a tag that does not exist
yet harms nothing; the other order breaks `curl | sh` for everyone in between.

### What is in 0.14.1

Everything here came from users of 0.14.0.

- **#94** — downloaded recordings were always named `.h264`. They are not an
  elementary stream at all: every file begins `…ftyp iso4`, an **MP4
  container**. The old sniffer looked for Annex-B start codes, found the
  `00 00 00 01` that happens to sit inside an MP4 header, read a meaningless
  NAL type, and fell back to `h264` — which is why *every* download got that
  name whatever the codec. Downloads are now `<recording>.mp4`.
- **#92** — `--password-stdin` blocked on a terminal with nothing on screen,
  which reads as a hang. It now says what it is waiting for, in wording checked
  under a pty: a single Ctrl-D after the password does not end the read, so the
  hint says *press Enter, then Ctrl-D*. The flag is also global now, matching
  `--password` — it previously existed only on `device add` / `device update`
  while every other command advised using it.
- **#93** — `vod download --directory <DIR>` chooses where recordings land,
  created if missing, for one recording or many. Previously the only way was to
  `cd` first, which an MCP client or an agent cannot do.
- **#91** — camera names have no rules (spaces, mixed case, non-ASCII all
  work), but a name with a space needs shell quotes and every example showed
  the hyphenated form. Documented in `device add --help`, the command reference
  and the bundled skill.

### Verification

- All eight external artifacts built; the P2P fingerprint gate reports
  `clean (external)` for every one. The finished archives were scanned too: 0
  fingerprints and 0 bundled P2P libraries, against 170 in an internal build
  used as a positive control, so the scan is known to work.
- `reolink-cli --version` → `0.14.1 (external · LAN-only)`, and the shipped
  binary carries the new `--directory` flag.
- Checksums recomputed independently from the archives and matched against the
  per-artifact sidecars, 8/8.
- Verified against a real Reolink Home Hub 2 (v3.3.0.579): downloads land as
  `.mp4` and `ffprobe` agrees, `--directory` creates and fills the directory,
  and a piped password logs in while a wrong one is rejected.
- The terminal behaviour of `--password-stdin` was verified under a pty, which
  is how the first version of the hint was caught being wrong.
- 749 tests pass. Two of the new ones exist to stop a flag pair silently doing
  the wrong thing: `--file` with `--directory`, and `--password` with
  `--password-stdin`, both must refuse rather than quietly ignore one.
- `./scripts/check-version-sync.sh --self` passes.

Installer end-to-end runs (macOS + Alpine on both architectures) come after the
release is published, since they resolve the latest release.
