### PR TITLE
release: 0.14.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "reolink-cli",
       "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "source": "./",
       "author": {
         "name": "Reolink"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "author": {
     "name": "reolink"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Plugin for operating Reolink cameras through the local CLI.",
   "author": {
     "name": "Reolink"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "reolink-cli",
   "displayName": "Reolink CLI",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "author": {
     "name": "Reolink"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,54 @@ All notable changes to the public `reolink-cli` distribution are documented here
 This is the customer-facing release history; it tracks the LAN-only (external)
 builds published as GitHub Releases.
 
+## [0.14.2] — 2026-08-28
+
+Three Home Hub defects, all verified on a Home Hub 2 with three child cameras.
+
+### Fixed
+
+- **A hub channel reported the hub's own model, not the child camera's**
+  (#99, reported by **@ridome**). `info` sends a device-level command, so every
+  channel of a hub answered `Reolink Home Hub 2` and the child cameras were
+  invisible — leaving an agent unable to tell what any given channel could
+  actually do. There is a per-channel equivalent in the protocol that was
+  simply not implemented. `info` now reports the child under its own `channel`
+  object:
+
+  ```
+  hub-ch0  hub=Reolink Home Hub 2 | child: Argus PT Ultra   / v3.0.0.4739 / Front Door
+  hub-ch1  hub=Reolink Home Hub 2 | child: Reolink Argus PT / v3.0.0.5585 / Back Door
+  hub-ch2  hub=Reolink Home Hub 2 | child: OMVI 2i Ultra    / v3.0.0.6976 / Back Yard
+  ```
+
+  Deliberately a separate object rather than merged into the top level: a
+  caller deciding what a camera supports must not mistake hub metadata for the
+  child's. Serial number, hardware version and build day come through too.
+
+- **`audio siren play` reported the siren was sounding when the device had only
+  acknowledged the command** (#95, reported by **@ridome**). `state: "on"` was
+  a hard-coded string — it was never evidence. Measured on a Home Hub 2: the
+  command returned 200 on two channels while no `siren.on` report arrived on
+  any of them, so an agent faithfully relayed a success the CLI had invented.
+
+  There is no way to ask a v2.0 device whether its siren is sounding, so rather
+  than fake verification the response now states only what is known:
+  `accepted`, the requested duration, send and expected-stop timestamps, and
+  `verified: false`, with a pointer to `events stream` where a device that does
+  sound emits `siren.on` / `siren.off`.
+
+- **The first spotlight command to a hub child camera could fail with `400`**
+  (#97, reported by **@ridome**). The pattern was `400, ok, ok` — try it once
+  and you conclude the feature is unsupported, though all three child cameras
+  turn their light on and off normally.
+
+  The trigger could not be pinned: it did not correlate with how long the
+  camera had been idle (after 120s the first call succeeded), nor with a
+  freshly started gateway. So this does not pretend to know why — it retries on
+  a device-side `400` with a bounded backoff and reports `retried` so the
+  caller can see it happened. A `405`, meaning the model has no spotlight, is
+  not retried.
+
 ## [0.14.1] — 2026-08-28
 
 Three defects reported by users of 0.14.0, plus a documentation gap that took

--- a/checksums/v0.14.2.sha256
+++ b/checksums/v0.14.2.sha256
@@ -1,0 +1,8 @@
+86cdbb629e341ad3f5ac46c3c1c1e7e346b21e49c78f8fea5fdaf28af400245c  reolink-cli-0.14.2-external-darwin-arm64.tar.gz
+5ed313f6e1b779a2a8799ad67f94a7ae9908fbdded25e8fcdbd7f87462336083  reolink-cli-0.14.2-external-linux-arm64-musl.tar.gz
+9a533f25a07ad6355f0be89a1fef4cbe793ce983bd55090640f6c099765a4ddd  reolink-cli-0.14.2-external-linux-arm64.tar.gz
+4521679a9a43a115a83848f52766b9296b4053b6b85276b3362dd1a31e3af5dd  reolink-cli-0.14.2-external-linux-armv6.tar.gz
+7a961f4ce02c82d5a3e8dde603ce03235fd8f392e6d282246dac6f6c3412ba7f  reolink-cli-0.14.2-external-linux-armv7.tar.gz
+4e622b53a784adb14408adbd6d0722d2a19fd5ca8dd0270fd84fc901cdb95b91  reolink-cli-0.14.2-external-linux-x86_64-musl.tar.gz
+c6c6c7f3b838347d937be88790d8e0cf731b2096e9f4117d3b09eb1461bc03a7  reolink-cli-0.14.2-external-linux-x86_64.tar.gz
+bf9cc398ae6b871f1c0089093b4582d7e414e8217ed4a5bcb31a6c4e5f772fbd  reolink-cli-0.14.2-external-windows-x86_64.zip

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "contextFileName": "GEMINI.md",
   "mcpServers": {
     "reolink": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "reolink-cli",
   "name": "Reolink CLI",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "author": {
     "name": "Reolink"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "type": "module",
   "description": "Operate Reolink cameras locally via reolink-cli.",
   "main": ".opencode/plugins/reolink-cli.js",


### PR DESCRIPTION
Release sync for **0.14.2**.

Lands `checksums/v0.14.2.sha256` **before** the release is published — the
installers resolve the latest release and then look for its checksum file here,
and they fail closed. The other order breaks `curl | sh` for everyone in
between.

### What is in 0.14.2

Three Home Hub defects, all reported by @ridome and all verified on a Home Hub 2
with three child cameras (Argus PT Ultra, Reolink Argus PT, OMVI 2i Ultra).

- **#99** — a hub channel reported the hub's own model. `info` sends a
  device-level command, so every channel answered `Reolink Home Hub 2` and the
  children were invisible. The per-channel equivalent existed in the protocol
  and was simply not implemented; the child now appears under its own `channel`
  object, kept separate so hub metadata is never mistaken for a child's
  capabilities.
- **#95** — `audio siren play` claimed the siren was sounding on nothing more
  than a device acknowledgement. `state: "on"` was hard-coded. Measured: the
  command returned 200 while no `siren.on` report arrived, so an agent relayed
  a success the CLI had invented. The response now reports `accepted`,
  timestamps and `verified: false`, and points at `events stream` for the
  confirmation the protocol can actually provide.
- **#97** — the first spotlight command to a hub child could fail `400`, making
  a working feature look unsupported. The trigger could not be pinned (it did
  not correlate with idle time or a fresh gateway), so the fix retries on `400`
  with a bounded backoff and reports `retried` rather than inventing a cause. A
  `405` — no spotlight on that model — is not retried.

### Verification

- All eight external artifacts built; the P2P gate reports `clean (external)`
  for every one. The finished archives were scanned too: 0 fingerprints and 0
  bundled P2P libraries, against 170 in an internal build used as a positive
  control.
- `reolink-cli --version` → `0.14.2 (external · LAN-only)`.
- Checksums recomputed independently and matched against the sidecars, 8/8.
- On device: three channels return three distinct child models; the siren
  response contains no unverified `state: "on"`; a channel that answered `400`
  succeeded after retry in 6.8s while a healthy one returned in 0.3s and a
  genuinely unsupported command still failed in under 100ms.
- 752 tests pass, including three new ones asserting that only a `400` is
  retried — a `405` or an auth/transport failure must not be.
- `./scripts/check-version-sync.sh --self` passes.
