### PR TITLE
release: 0.16.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "reolink-cli",
       "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "source": "./",
       "author": {
         "name": "Reolink"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "author": {
     "name": "reolink"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Plugin for operating Reolink cameras through the local CLI.",
   "author": {
     "name": "Reolink"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "reolink-cli",
   "displayName": "Reolink CLI",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "author": {
     "name": "Reolink"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,57 @@ All notable changes to the public `reolink-cli` distribution are documented here
 This is the customer-facing release history; it tracks the LAN-only (external)
 builds published as GitHub Releases.
 
+## [0.16.1] — 2026-09-04
+
+Three fixes, all of them cases where the CLI knew what had gone wrong and told
+you something else — or nothing at all.
+
+### Fixed
+
+- **A failed single-file `vod download` now reports the device's actual error
+  ([#105]).** Internally a download emits `file started` → `file skipped:
+  <reason>` → `error: <reason>`, and the reader stopped at the skip marker. So
+  *every* single-file failure was replaced by the hint reserved for a download
+  that streams nothing and gives no reason — advice about waking battery
+  cameras behind a hub, which reached someone whose recordings were on an NVR.
+  Reproduced here on a Home Hub with a recording name that does not exist: one
+  name produced the battery text, the same request with two names (the batch
+  path, which was always correct) produced `device rejected command 14 (400)`.
+  The hint stays, for the case it was written for.
+
+- **"Recording not found" now says which channel it searched.** A download
+  re-searches the recording to get its exact window, and a hub or NVR files
+  recordings per channel — so a name copied out of `vod search --channel 7` and
+  downloaded without `--channel` is genuinely absent, and the old message read
+  like the recording was gone. It now names the channel, and reads the likely
+  one back out of the recording name (the leading two digits are the 1-based
+  channel):
+
+  ```
+  recording '0820260831070001' not found on channel 0 in the search of 2026-08-31 —
+  the name starts with '08', which usually means channel 7. Pass the same `--channel`
+  you searched with.
+  ```
+
+  It only says so; it will not silently download from a different channel.
+
+- **Aliases carrying both a `host` and a `uid` can use the media endpoints
+  again.** Login routed such a target by uid (it runs a connect race, with the
+  IP as a LAN hint) while the media URL named the IP, so the gateway's binding
+  check rejected the token it had just issued — `token does not match host`,
+  which disabled `snapshot`, `preview` and `vod download` for those aliases
+  entirely. Not a regression; it had been true for several releases. The media
+  request now routes exactly like the login.
+
+- **Preview no longer dies about 11 seconds in on battery devices.** A battery
+  camera sends a heartbeat during a session and closes the session when the
+  client never answers. That answer existed only inside the recording-download
+  loop; every other long-running command reads through a shared loop that
+  dropped the frame. Measured on a battery doorbell: preview ran 11.0s, 10.9s
+  and 11.0s before, and 30s+ after, with every packet accounted for.
+
+[#105]: https://github.com/reolink/reolink-cli/issues/105
+
 ## [0.16.0] — 2026-09-02
 
 Snapshots got faster, and one class of snapshot stopped failing outright. Both

--- a/checksums/v0.16.1.sha256
+++ b/checksums/v0.16.1.sha256
@@ -1,0 +1,8 @@
+e5791a5ed352425545d744419f0a71012df9ee68aa60607f04ed689f7063c61a  reolink-cli-0.16.1-external-darwin-arm64.tar.gz
+16f19330a7dff5c0512b1f4319fdf29251c60bcba0731e25040f8f7e03e911e4  reolink-cli-0.16.1-external-linux-arm64-musl.tar.gz
+ba90d918f3c27865de3cc5d6a08187ee07968a2ffcb6ad1fe9f5323efbebd95f  reolink-cli-0.16.1-external-linux-arm64.tar.gz
+c7fe5aa6c9efb2f6eb0947ac2075f5037c7e9cff2396c0b293c88c847bdcaa90  reolink-cli-0.16.1-external-linux-armv6.tar.gz
+b33faaf9c85f1ae586daad885562161454aada66777fdc1c0dbbf8f456366a2d  reolink-cli-0.16.1-external-linux-armv7.tar.gz
+9fe11d5c7bfc14c7941d5a42d645749be7892c200d995bef18796d7a793c833f  reolink-cli-0.16.1-external-linux-x86_64-musl.tar.gz
+2791a509739d2cda08024b66065603d87f9c775ea80f0d1a5c7de8d18c722818  reolink-cli-0.16.1-external-linux-x86_64.tar.gz
+89ac5ed95a9e380be397317d4e2dfa6e0b530353c499ee3c33595d5f8661424d  reolink-cli-0.16.1-external-windows-x86_64.zip

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "contextFileName": "GEMINI.md",
   "mcpServers": {
     "reolink": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "reolink-cli",
   "name": "Reolink CLI",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "author": {
     "name": "Reolink"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "type": "module",
   "description": "Operate Reolink cameras locally via reolink-cli.",
   "main": ".opencode/plugins/reolink-cli.js",


### PR DESCRIPTION
Three fixes, all cases where the CLI knew what had gone wrong and reported something else.

- A failed single-file `vod download` reported the hint reserved for an empty stream — advice about battery cameras behind a hub — instead of the device's error, because the reader stopped at the skip marker that precedes it (#105). Reproduced on a Home Hub with a name that does not exist: one name gave the battery text, two names (the batch path) gave `device rejected command 14 (400)`.
- "Recording not found" now names the channel it searched, and the channel the recording name points at.
- Aliases carrying both a `host` and a `uid` could not use `snapshot`, `preview` or `vod download` at all: login routed by uid, the media URL named the IP, and the gateway rejected its own token with `token does not match host`. Not a regression.
- Preview no longer dies ~11s in on battery devices; the heartbeat answer lived in only one of the two receive loops.

Artifacts built external (LAN-only, no P2P) for all 8 platforms; the P2P fingerprint gate reports clean on every one, and `checksums/v0.16.1.sha256` comes from the build machine.
