### PR TITLE
release: 0.17.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "reolink-cli",
       "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-      "version": "0.16.1",
+      "version": "0.17.0",
       "source": "./",
       "author": {
         "name": "Reolink"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "author": {
     "name": "reolink"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "Plugin for operating Reolink cameras through the local CLI.",
   "author": {
     "name": "Reolink"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "reolink-cli",
   "displayName": "Reolink CLI",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "author": {
     "name": "Reolink"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,61 @@ All notable changes to the public `reolink-cli` distribution are documented here
 This is the customer-facing release history; it tracks the LAN-only (external)
 builds published as GitHub Releases.
 
+## [0.17.0] — 2026-09-04
+
+`vod download` can now ask the camera for a time range and let it do the
+cutting, instead of fetching whole recordings and trimming them yourself.
+
+### Added
+
+- **`vod download --from/--to` — a time range, cut by the device ([#105]).**
+
+  ```sh
+  reolink-cli vod download --from 2026-09-02T09:45:00 --to 2026-09-02T09:55:00 \
+    --channel 5 --directory ./clips
+  ```
+
+  On an NVR a recording is typically a whole hour, so ten minutes of it used to
+  mean downloading a gigabyte and throwing away nine tenths of it — and a window
+  crossing the hour meant two files to join by hand.
+
+  There is no protocol document for this device command, so every statement
+  below is measured rather than quoted:
+
+  - **One request returns one recording.** The device answers with the *first*
+    recording the window touches, clipped to the window; a window starting in a
+    gap skips forward to the next recording. Verified against frame counts on
+    four windows of the same camera — 15s inside one recording gave 241 frames,
+    the whole 49s recording gave 749, a window spanning three recordings still
+    gave 749 (it stopped at the first one's end), and a window starting in a gap
+    gave 781 from the second recording.
+
+    So the CLI searches the window first and asks once per recording in it,
+    joining the pieces. That is what makes a window crossing a recording
+    boundary — on a continuously-recording NVR, any window crossing the hour —
+    come back whole. The three-recording window above joins to 2165 frames,
+    8.87 MB, in 3.4 s.
+
+  - **The output is an elementary stream, not MP4.** A download by name hands
+    back the MP4 the device stored; a cut is produced live and arrives as media
+    packets, so it lands as `.hevc` or `.h264`. Wrap it with
+    `ffmpeg -i clip.hevc -c copy clip.mp4` if you need a container.
+
+  - **Not every model implements it.** Nothing in the capability list advertises
+    it either; a model that lacks it answers 400, and downloading whole
+    recordings by name is unaffected.
+
+### Fixed
+
+- **`--directory` no longer renames a download to a guess.** Only the response
+  knows what the bytes turned out to be — the extension is read off the real
+  container or codec — but the `--directory` path used a name built before the
+  request went out. Downloading by name happened to be right (the device really
+  does return MP4); a cut got a raw HEVC stream in a file called `.mp4`.
+  `--file` still names an exact path; everything else now follows the response.
+
+[#105]: https://github.com/reolink/reolink-cli/issues/105
+
 ## [0.16.1] — 2026-09-04
 
 Three fixes, all of them cases where the CLI knew what had gone wrong and told

--- a/checksums/v0.17.0.sha256
+++ b/checksums/v0.17.0.sha256
@@ -1,0 +1,8 @@
+75ffc23407e6b784fc0cd87a1adc035db7d84142705ac2d506af1754156286ea  reolink-cli-0.17.0-external-darwin-arm64.tar.gz
+d7ae56b7e9c3738f53bb65e70f31fe9222cba4d6fda4d20bd0ce07bd21358aaf  reolink-cli-0.17.0-external-linux-arm64-musl.tar.gz
+fb61f6567eb7d1a7ad5f55416615217eb42629d49d7b9a92dbafe368d1f5e41f  reolink-cli-0.17.0-external-linux-arm64.tar.gz
+3d0c3e7d9298c7fe268c22c9230161de10f75deee729e09dd9a9425d431f4974  reolink-cli-0.17.0-external-linux-armv6.tar.gz
+362b80c718cb0f8cdc35495cb00083dd405787b8e3352d2d51d5de9be66204bc  reolink-cli-0.17.0-external-linux-armv7.tar.gz
+21dfecef2b85a85b92edd172c4e845b9ec490adc183f75da1aab96f6bed2d44f  reolink-cli-0.17.0-external-linux-x86_64-musl.tar.gz
+bbe379e5839f56acc58a2ced16a576df7943fd4249748b49ff2a621ef4f69ecc  reolink-cli-0.17.0-external-linux-x86_64.tar.gz
+2f4cb40d0634c718c548a5a44e0b8f86f8d5f3171f15409c1838b9dfb9f4c8a6  reolink-cli-0.17.0-external-windows-x86_64.zip

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "contextFileName": "GEMINI.md",
   "mcpServers": {
     "reolink": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "reolink-cli",
   "name": "Reolink CLI",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "author": {
     "name": "Reolink"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "type": "module",
   "description": "Operate Reolink cameras locally via reolink-cli.",
   "main": ".opencode/plugins/reolink-cli.js",

--- a/skills/reolink-cli/SKILL.md
+++ b/skills/reolink-cli/SKILL.md
@@ -102,6 +102,7 @@ Resolve ambiguity before picking a command. If still unclear, **ask with options
 | SD card / storage card / capacity / free space | `storage status` | Read-only; totalGB / remainGB / formatted / mounted |
 | manual record / record now / start recording | — | **Not supported** on Reolink IPCs; fall back to `record schedule set --enable/--disable` |
 | download yesterday / download recording | `vod search --since 24h` → `vod download NAME` | |
+| download 09:45–09:55 / just that clip / a time range | `vod download --from 2026-09-02T09:45:00 --to 2026-09-02T09:55:00` | Camera-side cut — do NOT download the whole hour and trim |
 | any alarms / any alarms today | `events query --since 24h` | Requires gateway |
 | event history further back than the live buffer / what happened last week / hub event log | `--channel N events history --since 7d [--types people,motion]` (hub/NVR only) | Reads the device's recorded event log (cmd 516/517), not the ~500-entry live ring. Standalone IPCs 400. Empty list = no matching events; a hub can go briefly quiet after heavy use, retry after a pause. |
 | voice alert / voice announcement / announce when someone arrives / play voice when a person is detected | `audio talk` (see `references/voice-alert.md`) | PCM16 LE mono only; needs `capabilities.audioTalk=1` |
@@ -257,7 +258,7 @@ A scene is a named set of per-channel task bits, so switching scenes re-arms the
 
 **Storage:** `storage status` (read-only SD/HDD capacity + mount state). **Forbidden** format/init ops — direct users to the Reolink app if they need to format.
 
-**VOD:** `vod search [--from ISO --to ISO | --since DURATION] [--type T,...] [--stream main|sub] [--limit N]`, `vod download NAME [-o FILE]`. Time must be **naive local ISO** (`YYYY-MM-DDTHH:MM:SS`, no TZ, no ms). Cross-month windows are handled for you (the gateway splits at month boundaries and merges); `limit` applies to the merged list, and `truncated` tells you it cut short. Filenames case-sensitive.
+**VOD:** `vod search [--from ISO --to ISO | --since DURATION] [--type T,...] [--stream main|sub] [--limit N]`, `vod download NAME [-o FILE]`, `vod download --from ISO --to ISO` (time range, the **camera** cuts it — one request per recording segment, joined; output is an Annex-B `.hevc`/`.h264` elementary stream, not MP4; unsupported models answer 400). Time must be **naive local ISO** (`YYYY-MM-DDTHH:MM:SS`, no TZ, no ms). Cross-month windows are handled for you (the gateway splits at month boundaries and merges); `limit` applies to the merged list, and `truncated` tells you it cut short. Filenames case-sensitive.
 Types: `manual|sched|io|md|people|vehicle|face|dog_cat|visitor|other|package`
 
 **Detection:** `detect motion {get|set|apply [--enable|--disable] [--sensitivity 0-100] [--use-pir|--disable-pir]}`, `detect ai {get|set|apply} --type TYPE [--sensitivity 0-100] [--stay-time SECS]`. `apply` is the idempotent recipe — prefer it for "set sensitivity to N"-style intent. AI types: `person|vehicle|dog_cat|package|cry` (subset varies by model).


### PR DESCRIPTION
`vod download` can now ask the camera for a time range and let it do the cutting (#105).

```sh
reolink-cli vod download --from 2026-09-02T09:45:00 --to 2026-09-02T09:55:00 --channel 5 --directory ./clips
```

There is no protocol document for the device command behind this, so the behaviour was measured rather than quoted:

- **One request returns one recording** — the first the window touches, clipped to it; a window starting in a gap skips to the next. Verified by frame count on four windows (241 / 749 / 749 / 781 frames). So the CLI searches the window and asks once per recording, joining the pieces — which is what makes a window crossing the hour come back whole (three recordings → 2165 frames, 8.87 MB, 3.4 s).
- **The output is an elementary stream** (`.hevc`/`.h264`), not MP4: a cut is produced live rather than read from a stored file.
- **Not every model implements it**, and nothing in the capability list advertises it. Those answer 400; download-by-name is unaffected.

Also fixed: `--directory` used a file name guessed before the request went out, so a raw HEVC cut landed in a file called `.mp4`.

Artifacts built external (LAN-only, no P2P) for all 8 platforms; the P2P fingerprint gate reports clean on every one, and `checksums/v0.17.0.sha256` comes from the build machine.
