### PR TITLE
release: 0.17.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "reolink-cli",
       "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "source": "./",
       "author": {
         "name": "Reolink"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "author": {
     "name": "reolink"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Plugin for operating Reolink cameras through the local CLI.",
   "author": {
     "name": "Reolink"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "reolink-cli",
   "displayName": "Reolink CLI",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "author": {
     "name": "Reolink"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to the public `reolink-cli` distribution are documented here
 This is the customer-facing release history; it tracks the LAN-only (external)
 builds published as GitHub Releases.
 
+## [0.17.1] — 2026-09-04
+
+### Fixed
+
+- **A device refusing a download no longer reads as the stream simply ending.**
+  The receive loop treated an empty frame as end-of-stream, and a refusal *is*
+  an empty frame carrying a non-200 code — so the refusal was swallowed and the
+  time-range download reported "no recording in that window" instead. On a model
+  that does not implement the cut command at all, that diagnosis is wrong and
+  sends you looking in the wrong place ("but I can see the recordings").
+
+  Response codes are now read the way the reference implementation reads them:
+  200 carries data, 300 ends a download by name, 331 ends a cut, and anything
+  else is the device saying no — reported as the device error it is.
+
+  This came out of a control experiment worth recording: an NVR answered 400 to
+  the cut command, but so did a camera that demonstrably **does** support it,
+  when asked for a window holding no recording. A 400 therefore cannot tell
+  "unsupported" from "nothing there" — v0.17.0's release note implied it could.
+  Since the CLI searches before it cuts, a 400 arriving *after* recordings were
+  found is now reported for what it most likely is: this model has no cut
+  download, and `vod download <name>` still works.
+
 ## [0.17.0] — 2026-09-04
 
 `vod download` can now ask the camera for a time range and let it do the

--- a/checksums/v0.17.1.sha256
+++ b/checksums/v0.17.1.sha256
@@ -1,0 +1,8 @@
+494f9fc37f34975840a94dbb7d5c22ad36a05f90238f22ff228f65bf44e9bd12  reolink-cli-0.17.1-external-darwin-arm64.tar.gz
+6a0544cd9e68cddbaf94f54d46fced72c973e2d26596ad09dae966e30f5c81ef  reolink-cli-0.17.1-external-linux-arm64-musl.tar.gz
+5c08a0d76d9531706170da4e95f294b6ef3de9e3d545bdc985edf0f9ad7560c3  reolink-cli-0.17.1-external-linux-arm64.tar.gz
+dabfc0f5be03b7ce60719bb0ca65bc0f13e88494ca6f0d9c9f1714ffeaea4a28  reolink-cli-0.17.1-external-linux-armv6.tar.gz
+bbae44d28b9f389531589cb2762deac995222aedd3e364a91d1a7b0caf76c89f  reolink-cli-0.17.1-external-linux-armv7.tar.gz
+414af0e678a440ca3d0ad4138bd50da7569253110141bde6ab87aea6c553224a  reolink-cli-0.17.1-external-linux-x86_64-musl.tar.gz
+bca1d4715d2d05104fbeaca3457ae49493d0ed1e1ee078440a59fcae9fac69a2  reolink-cli-0.17.1-external-linux-x86_64.tar.gz
+d4eed62951561fd74cabbc01c48a033004736dfd8940b36ebfc3a325ddffbcda  reolink-cli-0.17.1-external-windows-x86_64.zip

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "contextFileName": "GEMINI.md",
   "mcpServers": {
     "reolink": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "reolink-cli",
   "name": "Reolink CLI",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "author": {
     "name": "Reolink"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "type": "module",
   "description": "Operate Reolink cameras locally via reolink-cli.",
   "main": ".opencode/plugins/reolink-cli.js",


### PR DESCRIPTION
A device refusing a download no longer reads as the stream simply ending.

The receive loop treated an empty frame as end-of-stream, and a refusal *is* an empty frame carrying a non-200 code — so the refusal was swallowed and a time-range download reported "no recording in that window" instead. On a model that does not implement the cut command at all, that diagnosis is wrong and sends you looking in the wrong place.

Response codes are now read the way the reference implementation reads them: 200 carries data, 300 ends a download by name, 331 ends a cut, anything else is the device saying no.

This came out of a control experiment worth recording: an NVR answered 400 to the cut command, but so did a camera that demonstrably **does** support it, when asked for a window holding no recording. A 400 therefore cannot tell "unsupported" from "nothing there" — v0.17.0's note implied it could. Since the CLI searches before it cuts, a 400 arriving *after* recordings were found is now reported for what it most likely is.

Regression test drives the whole path over a scripted transport (login → search → a 400 frame); with the fix reverted it fails on exactly the old wrong message.

Artifacts built external (LAN-only, no P2P) for all 8 platforms; the P2P fingerprint gate reports clean on every one, and `checksums/v0.17.1.sha256` comes from the build machine.
