### PR TITLE
release: 0.18.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "reolink-cli",
       "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-      "version": "0.18.1",
+      "version": "0.18.2",
       "source": "./",
       "author": {
         "name": "Reolink"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "author": {
     "name": "reolink"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "Plugin for operating Reolink cameras through the local CLI.",
   "author": {
     "name": "Reolink"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "reolink-cli",
   "displayName": "Reolink CLI",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "author": {
     "name": "Reolink"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to the public `reolink-cli` distribution are documented here
 This is the customer-facing release history; it tracks the LAN-only (external)
 builds published as GitHub Releases.
 
+## [0.18.2] — 2026-09-07
+
+### Fixed
+
+- **A cut's reported frame rate came from the wrong place, and remuxing against
+  it changed the clip's length (#105).** 0.18.1 was right to pass a rate through
+  and wrong about where to read it: it used the byte in the stream's own info
+  header, which is correct on the sub stream and wrong on the main one, where it
+  announces a nominal 30 rather than what is delivered.
+
+  Measured on a Home Hub 2, main stream: the encoder reports 15, an 11-second
+  cut holds 162 frames (14.7 fps), and the header claims 30. Remuxed at 30, a
+  10.8-second clip became 5.4 — exactly half. The reporter's 25 fps cameras got
+  the same 30, turning an 11:00 clip into 9:10; 25/30 is precisely that ratio.
+
+  The rate now comes from the channel's encoder configuration, the source that
+  matched the frame count on every measurement. A device that does not answer
+  that command simply gets no `-r` hint and the cut itself is unaffected. A test
+  pins the header out of the path, so it cannot be reconnected by good
+  intentions.
+
 ## [0.18.1] — 2026-09-06
 
 Both of these were found only after the reporter of #105 ran the real thing and

--- a/checksums/v0.18.2.sha256
+++ b/checksums/v0.18.2.sha256
@@ -1,0 +1,8 @@
+fb5fe460ff8f3b020348046ca9844e6bafa9ac2ae41df512df46c259c9147129  reolink-cli-0.18.2-external-darwin-arm64.tar.gz
+cd9b380a21a532d82dbfe0876a80dc459b764a06eb8e95435294b6fc738d4be9  reolink-cli-0.18.2-external-linux-arm64-musl.tar.gz
+8ece9e54a0fafead1c70a90497936180b166aa408556a8db97c30e370f0e970f  reolink-cli-0.18.2-external-linux-arm64.tar.gz
+3b56565948ebb79fae08c03ea238ec22a9e58fd8d9c93bfbe44a0a661385eee8  reolink-cli-0.18.2-external-linux-armv6.tar.gz
+cd4af38ba5384e9073ca24b1708bbf038ee33a386a961e4366e2dc1302f69e00  reolink-cli-0.18.2-external-linux-armv7.tar.gz
+9c73b0ebb300f770f82f002c0ee71971eddf23ac306c681b67d2bb1d831b6888  reolink-cli-0.18.2-external-linux-x86_64-musl.tar.gz
+5e5ef00a93a4d04d205a47f2d5ee14ba17d415ae180228cb42f27be54c15f5f3  reolink-cli-0.18.2-external-linux-x86_64.tar.gz
+904c367e9aaef43542dab05a250ad8bc0a65c7ab3bce74bf59e2865fa51c4701  reolink-cli-0.18.2-external-windows-x86_64.zip

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "contextFileName": "GEMINI.md",
   "mcpServers": {
     "reolink": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "reolink-cli",
   "name": "Reolink CLI",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "author": {
     "name": "Reolink"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "type": "module",
   "description": "Operate Reolink cameras locally via reolink-cli.",
   "main": ".opencode/plugins/reolink-cli.js",


### PR DESCRIPTION
**A cut's reported frame rate came from the wrong place, and remuxing against it changed the clip's length (#105).**

0.18.1 was right to pass a rate through and wrong about where to read it: it used the byte in the stream's own info header, which is correct on the sub stream and wrong on the main one, where it announces a nominal 30 rather than what is delivered.

Measured on a Home Hub 2, main stream: the encoder reports 15, an 11-second cut holds 162 frames (14.7 fps), and the header claims 30. Remuxed at 30, a 10.8-second clip became 5.4 — exactly half. The reporter's 25 fps cameras got the same 30, turning an 11:00 clip into 9:10; 25/30 is precisely that ratio.

The rate now comes from the channel's encoder configuration, the source that matched the frame count on every measurement. A device that does not answer that command simply gets no `-r` hint and the cut itself is unaffected. A test pins the header out of the path.

Re-verified before release on a second camera: the encoder reports 15 for the main stream, the cut reports 15, and the remuxed clip measures 49.933 s over 749 frames against 49.828 s for the same recording downloaded whole by name.

Artifacts built external (LAN-only, no P2P) for all 8 platforms; the P2P fingerprint gate reports clean on every one, and `checksums/v0.18.2.sha256` comes from the build machine.
