### PR TITLE
release: 0.18.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "reolink-cli",
       "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-      "version": "0.18.2",
+      "version": "0.18.3",
       "source": "./",
       "author": {
         "name": "Reolink"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "author": {
     "name": "reolink"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "description": "Plugin for operating Reolink cameras through the local CLI.",
   "author": {
     "name": "Reolink"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "reolink-cli",
   "displayName": "Reolink CLI",
   "description": "Operate Reolink cameras locally: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "author": {
     "name": "Reolink"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to the public `reolink-cli` distribution are documented here
 This is the customer-facing release history; it tracks the LAN-only (external)
 builds published as GitHub Releases.
 
+## [0.18.3] — 2026-09-07
+
+Found while checking a report that `discover` does not see battery cameras. It
+does not, and there are two separate reasons.
+
+### Fixed
+
+- **A Home Hub with a single paired camera can be expanded now.** `device
+  expand` answered this, on a device that is a Hub and has a battery video
+  doorbell on channel 0:
+
+  ```
+  camera hub has a single populated channel (0); nothing to expand (not an NVR or Hub)
+  ```
+
+  — an inference stated as fact, and backwards. It treated "one populated
+  channel" as "this is a plain camera", but **one camera and one channel are
+  different claims**, and a hub with a single paired camera is both a real
+  setup and the one where expanding matters most: that child has no address on
+  the network, so `discover` cannot see it and this command is the only way to
+  register it.
+
+  The device already says which it is — the channel count reads 8 on that hub
+  and 1 on a plain camera — so the refusal now applies only when the device
+  itself does not claim more than one channel. Firmware that declines to report
+  a count keeps the old behaviour, because a lone channel there really is
+  indistinguishable from a plain camera. Verified: expanding registers the
+  child, and querying that entry reaches the doorbell.
+
+- **`device expand`'s help said Home Hub was unsupported.** Only `protocol=v30`
+  entries are refused; a Home Hub registered as v20 has always worked. The note
+  turned people away from a command that would have helped them.
+
+### Documentation
+
+- **`discover` now says what it cannot find**, in its own `--help`. Two kinds of
+  camera never answer, and neither is a fault in the scan: a **sleeping battery
+  camera** (the probe is answered by the camera's main application, which is
+  powered down while it sleeps — the same camera awake answers every time), and
+  a **camera paired to a Hub or NVR** (it has no address on the network at all;
+  the parent is what answers). Raising the timeout does not help: 2 s and 8 s
+  return the same list.
+
 ## [0.18.2] — 2026-09-07
 
 ### Fixed

--- a/checksums/v0.18.3.sha256
+++ b/checksums/v0.18.3.sha256
@@ -1,0 +1,8 @@
+90b50f6d446409fa9a60175d0ba5af5bd458d7cccfe4621aa087389f33e9e12e  reolink-cli-0.18.3-external-darwin-arm64.tar.gz
+559b87807b8fc9e91e3c76f771187397438deddfc0261c7fd24fd6a55fd8bc65  reolink-cli-0.18.3-external-linux-arm64-musl.tar.gz
+638466af90f610a5f928297b78dfb650e92981a7ab830149d09b97df4d4904df  reolink-cli-0.18.3-external-linux-arm64.tar.gz
+d78be85e5633b5be7ad018f76cc2ca08850d40e1198b1ecd82ef766f539494b1  reolink-cli-0.18.3-external-linux-armv6.tar.gz
+51cdebc0820400b3be88cfa3bcee95e8a8e74e04b041001b43d872650d93c0c1  reolink-cli-0.18.3-external-linux-armv7.tar.gz
+27b6d8a1a6d2040a2c50b83b580651e502cc445fd850110e0c03f7eb13bba079  reolink-cli-0.18.3-external-linux-x86_64-musl.tar.gz
+dfba686b6c47af7cf4d862e1b061e60d35a5ac05771f5214fb09caf2acf491c1  reolink-cli-0.18.3-external-linux-x86_64.tar.gz
+9cf59fbea3cbb1ac7fb92a0b3860af6ad82fc1e4bffd1ae370591c5bed468cea  reolink-cli-0.18.3-external-windows-x86_64.zip

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "reolink-cli",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "contextFileName": "GEMINI.md",
   "mcpServers": {
     "reolink": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "reolink-cli",
   "name": "Reolink CLI",
   "description": "Operate Reolink cameras locally via reolink-cli: discover, login, inspect, configure, preview, snapshot, and control PTZ/light/audio/detection/recording.",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "author": {
     "name": "Reolink"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reolink-cli",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "type": "module",
   "description": "Operate Reolink cameras locally via reolink-cli.",
   "main": ".opencode/plugins/reolink-cli.js",

--- a/skills/reolink-cli/SKILL.md
+++ b/skills/reolink-cli/SKILL.md
@@ -21,7 +21,7 @@ Primary surface: `reolink-cli` (JSON stdout by default). Don't start the MCP ser
 |---|---|---|
 | `/reolink-cli:status` | `reolink-cli status` | user asks about current state / dashboard / "how are things" |
 | `/reolink-cli:features` | `reolink-cli features` | user asks what the plugin can do / "what can it do" |
-| `/reolink-cli:scan` | `reolink-cli discover` | scan local network / "scan" |
+| `/reolink-cli:scan` | `reolink-cli discover` | scan local network / "scan". **Finds only devices that are awake and have their own LAN address** — a sleeping battery camera does not answer (the responder lives in the main application, which is powered down), and a camera paired to a hub/NVR has no address at all: use `device expand <parent>` for those. |
 | `/reolink-cli:devices` | `reolink-cli device list` | list registered cameras |
 | `/reolink-cli:cache-clean` | `reolink-cli cache clean` dry-run→apply | clear old snapshots / "clear cache" |
 | `/reolink-cli:update` | `reolink-cli self-update` | upgrade to the latest release (checks GitHub, no-op if current) |
@@ -84,7 +84,7 @@ Resolve ambiguity before picking a command. If still unclear, **ask with options
 | **slow / how long / time taken / performance / latency / benchmark** | **`benchmark [--iterations N] [--phases ...] [--reuse-session]`** | Per-phase p50/p95/p99: connect, login, info, snapshot. `--reuse-session` for warm-path. Detail in `references/index.md`. |
 | **cpu / memory / device load / is the camera overloaded / stuttering** | **`config get performance`** | Live reading from the device: `cpuUsedPercent`, `codeRate`, `netDataRate`. Read-only and instantaneous — two calls a second apart legitimately differ. Not every model implements it; those answer a device-level rejection. Distinct from `benchmark`, which times the **client** round trip, not the camera. |
 | **rtsp / rtmp / flv address / stream URL / HA / Frigate / go2rtc / VLC** | **`stream url [--kind rtsp,rtmp,flv] [--stream main,sub,ext] [--with-auth]`** | Default `--kind rtsp --stream main`. `--with-auth` only when user explicitly wants one-shot pasteable URL. NVR: `device expand` then `--tag <nvr>`. Detail in `references/media.md`. |
-| nvr with 8 channels / RLN sub-cameras / channel N | `device expand <nvr-name> [--yes \| --names A,B,C]` | **NVR only**. Registers one entry per channel, tagged with parent name. After: `--tag <nvr-name>` fans out. |
+| nvr with 8 channels / RLN sub-cameras / channel N / **cameras paired to a Home Hub** | `device expand <parent-name> [--yes \| --names A,B,C]` | Any **v20** parent — RLN NVRs and a Home Hub alike. Registers one entry per populated channel, tagged with the parent name; after: `--tag <parent>` fans out. **This is the only way to reach a battery camera paired to a hub** — it has no address of its own, so `discover` cannot see it. Refused for `protocol=v30` entries. |
 | command rejected 400 / "model doesn't support it" / battery camera on a hub / first command after a pause | Nothing — the gateway already retries. `attempts` in the answer says which try got through (3 is normal after a pause, 1 during a burst) | A battery child behind a hub sleeps and then rejects commands with a bare 400, indistinguishable from unsupported. **When** it sleeps is not predictable from idle time alone (one day's readings said ~2 min; later overnight windows found it awake), so do not try to pre-empt it. What is consistent: a sleeping camera costs a flat 3 attempts (~1.6 s) to wake, and the refused request is itself the wake. If it still fails after the budget, `info` → `channel.loginState` = `standby` explains it — but **that field lags**, so it explains a failure, it cannot pre-flight one. |
 | dual-lens / two lenses / bullet+PTZ in one camera / wide and telephoto / second lens | `info` first (`channel.views`, `channel.dualLens`), then `--view N` on config commands | `--view` is a **third** axis: `--channel` picks the camera, `--view` picks the lens, `--stream` picks that lens's encoding profile. Verified per-view: `encode`, `privacy mask`, `detect motion`, PTZ. **Not** per-view: `snapshot` (device answers 400 for view≥1), `preview`/`stream url` (protocol has no selector — these now **reject** `--view N` rather than silently handing back view 0), image/ISP (shared). Default 0 = the only view an ordinary camera has. |
 | **preview / take a look / watch N minutes / watch live** | **`preview play`** (opens ffplay window) | **DEFAULT to `play`, not `capture`.** User wants a live window, not a file. |
@@ -208,7 +208,7 @@ Signatures only — run `<cmd> --help` for flag details; see `references/<topic>
 
 **Discovery / Registry:** `discover`, `device list|resolve|show|add|update|remove|import|inventory|analyze|expand`, `config init`
 
-**NVR multi-channel:** `device expand <nvr-name> [--yes | --names A,B,C] [--drop-parent]`. RLN-series only; one entry per channel auto-tagged with parent name.
+**NVR / Hub multi-channel:** `device expand <parent-name> [--yes | --names A,B,C] [--drop-parent]`. Any v20 parent (RLN-series **and** Home Hub); one entry per populated channel, auto-tagged with the parent name. A hub's paired battery cameras are only reachable this way — they have no LAN address, so `discover` never lists them. `protocol=v30` entries are refused.
 
 **Identity:** `ping`, `login`, `info`, `capabilities`
 


### PR DESCRIPTION
Found while checking a report that `discover` does not see battery cameras. It does not, and there are two separate reasons.

**A Home Hub with a single paired camera can be expanded now.** `device expand` answered this, on a device that *is* a Hub and has a battery video doorbell on channel 0:

```
camera hub has a single populated channel (0); nothing to expand (not an NVR or Hub)
```

— an inference stated as fact, and backwards. It treated "one populated channel" as "this is a plain camera", but one camera and one channel are different claims, and a hub with a single paired camera is the case where expanding matters most: that child has no address on the network, so `discover` cannot see it and this command is the only way to register it. The device already says which it is — the channel count reads 8 on that hub and 1 on a plain camera — so the refusal now applies only when the device itself does not claim more than one channel. Verified: expanding registers the child, and querying that entry reaches the doorbell.

**`device expand`'s help said Home Hub was unsupported.** Only `protocol=v30` entries are refused; a Home Hub registered as v20 has always worked.

**`discover` now says what it cannot find**, in its own `--help`: a sleeping battery camera (the probe is answered by the camera's main application, powered down while it sleeps — the same camera awake answers every time) and a camera paired to a Hub or NVR (no address on the network at all; the parent answers). Raising the timeout does not help — 2 s and 8 s return the same list.

Artifacts built external (LAN-only, no P2P) for all 8 platforms; the P2P fingerprint gate reports clean on every one, and `checksums/v0.18.3.sha256` comes from the build machine.
